### PR TITLE
Rename Managers to Factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the importer of SwiftBeanCount. It reads files to create transactions. T
 
 ### Import Transactions
 
-1) Create a `FileImporter` via `FileImporterManager.new(ledger: Ledger?, url: URL?)` or a `TextImporter` via `TextImporterManager.new(ledger: Ledger?, transaction: String, balance: String)`, depending on what you want to import.
+1) Create a `FileImporter` via `ImporterFactory.new(ledger: Ledger?, url: URL?)` or a `Importer` via `ImporterFactory.new(ledger: Ledger?, transaction: String, balance: String)`, depending on what you want to import.
 2) Check `possibleAccounts()` on the importer. If there is more than one or none, promt to user to enter/select the account to use.
 3) Pass the result to the importer via `useAccount(name:)`.
 4) If using a FileImporter call `loadFile()`.
@@ -22,7 +22,7 @@ This is the importer of SwiftBeanCount. It reads files to create transactions. T
 
 The different importers which are included in this library can be configured:
 
-1) Call `ImporterManager.importers` to retreive all importers
+1) Call `ImporterFactory.allImporters` to retreive all importers
 2) Call `importer.settingsName` to get the user friendly name of the importer
 3) Call `importer.settings` to get the `ImporterSetting`s which an importer offers
 3) Use `importer.get(setting: ImporterSetting)` and `importer.set(setting: ImporterSetting, to value: String)` to modify these settings.

--- a/Sources/SwiftBeanCountImporter/CSVImporter.swift
+++ b/Sources/SwiftBeanCountImporter/CSVImporter.swift
@@ -18,7 +18,7 @@ struct CSVLine {
     let price: Amount?
 }
 
-enum CSVImporterManager {
+enum CSVImporterFactory {
 
     static var importers: [CSVImporter.Type] {
         [

--- a/Sources/SwiftBeanCountImporter/FileImporter.swift
+++ b/Sources/SwiftBeanCountImporter/FileImporter.swift
@@ -9,12 +9,12 @@
 import Foundation
 import SwiftBeanCountModel
 
-/// The FileImporterManager is responsible for the different types of `FileImporter`s.
+/// The FileImporterFactory is responsible for the different types of `FileImporter`s.
 /// It allow abstraction of the different importers by encapsulation to logic of which one to use.
-public enum FileImporterManager {
+enum FileImporterFactory {
 
     static var importers: [FileImporter.Type] {
-        CSVImporterManager.importers
+        CSVImporterFactory.importers
     }
 
     /// Returns the correct FileImporter, or nil if the file cannot be imported
@@ -23,8 +23,8 @@ public enum FileImporterManager {
     ///             e.g. to read attributes of accounts
     ///   - url: URL of the file to import
     /// - Returns: FileImporter, or nil if the file cannot be imported
-    public static func new(ledger: Ledger?, url: URL?) -> FileImporter? {
-        CSVImporterManager.new(ledger: ledger, url: url)
+    static func new(ledger: Ledger?, url: URL?) -> FileImporter? {
+        CSVImporterFactory.new(ledger: ledger, url: url)
     }
 
 }

--- a/Sources/SwiftBeanCountImporter/Importer.swift
+++ b/Sources/SwiftBeanCountImporter/Importer.swift
@@ -9,15 +9,38 @@
 import Foundation
 import SwiftBeanCountModel
 
-/// The ImporterManager is responsible for all different types of `Importer`s.
-public enum ImporterManager {
+/// The ImporterFactory is used to create the different importer types
+public enum ImporterFactory {
 
-    /// Return all existing importers
+    /// Return all existing importer types
     ///
     /// As the importers do not need to be called directly, this should only
     /// be used in the settings to allow displaying all settings of all importers
-    public static var importers: [Importer.Type] {
-        FileImporterManager.importers + TextImporterManager.importers
+    ///
+    /// - Returns: All existing importer types
+    public static var allImporters: [Importer.Type] {
+        FileImporterFactory.importers + TextImporterFactory.importers
+    }
+
+    // Returns a TextImporter, or nil if the text cannot be imported
+    /// - Parameters:
+    ///   - ledger: existing ledger which is used to assist the import,
+    ///             e.g. to read attributes of accounts
+    ///   - transaction: text of a transaction
+    ///   - balance: text of a balance
+    /// - Returns: TextImporter, or nil if the text cannot be imported
+    public static func new(ledger: Ledger?, transaction: String, balance: String) -> TextImporter? {
+        TextImporterFactory.new(ledger: ledger, transaction: transaction, balance: balance)
+    }
+
+    /// Returns a FileImporter, or nil if the file cannot be imported
+    /// - Parameters:
+    ///   - ledger: existing ledger which is used to assist the import,
+    ///             e.g. to read attributes of accounts
+    ///   - url: URL of the file to import
+    /// - Returns: FileImporter, or nil if the file cannot be imported
+    public static func new(ledger: Ledger?, url: URL?) -> FileImporter? {
+        FileImporterFactory.new(ledger: ledger, url: url)
     }
 
 }

--- a/Sources/SwiftBeanCountImporter/TextImporter.swift
+++ b/Sources/SwiftBeanCountImporter/TextImporter.swift
@@ -9,22 +9,22 @@
 import Foundation
 import SwiftBeanCountModel
 
-/// The TextImporterManager is responsible for the different types of `TextImporter`s.
+/// The TextImporterFactory is responsible for the different types of `TextImporter`s.
 /// It allow abstraction of the different importers by encapsulation to logic of which one to use.
-public enum TextImporterManager {
+enum TextImporterFactory {
 
     static var importers: [TransactionBalanceTextImporter.Type] {
         [ManuLifeImporter.self]
     }
 
-    /// Returns a the correct TextImporter, or nil if the text cannot be imported
+    /// Returns the correct TextImporter, or nil if the text cannot be imported
     /// - Parameters:
     ///   - ledger: existing ledger which is used to assist the import,
     ///             e.g. to read attributes of accounts
     ///   - transaction: text of a transaction
     ///   - balance: text of a balance
     /// - Returns: TextImporter, or nil if the text cannot be imported
-    public static func new(ledger: Ledger?, transaction: String, balance: String) -> TextImporter? {
+    static func new(ledger: Ledger?, transaction: String, balance: String) -> TextImporter? {
         ManuLifeImporter(ledger: ledger, transaction: transaction, balance: balance)
     }
 

--- a/Tests/SwiftBeanCountImporterTests/CSVImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/CSVImporterTests.swift
@@ -14,35 +14,35 @@ import XCTest
 final class CSVImporterTests: XCTestCase {
 
     func testImporters() {
-        XCTAssertEqual(CSVImporterManager.importers.count, 7)
+        XCTAssertEqual(CSVImporterFactory.importers.count, 7)
     }
 
     func testNew() {
         // no url
-        XCTAssertNil(CSVImporterManager.new(ledger: nil, url: nil))
+        XCTAssertNil(CSVImporterFactory.new(ledger: nil, url: nil))
 
         // invalid URL
-        XCTAssertNil(CSVImporterManager.new(ledger: nil, url: URL(fileURLWithPath: "DOES_NOT_EXIST")))
+        XCTAssertNil(CSVImporterFactory.new(ledger: nil, url: URL(fileURLWithPath: "DOES_NOT_EXIST")))
 
         // valid URL without matching headers
         let url = temporaryFileURL()
         createFile(at: url, content: "Header, no, matching, anything\n")
-        XCTAssertNil(CSVImporterManager.new(ledger: nil, url: url))
+        XCTAssertNil(CSVImporterFactory.new(ledger: nil, url: url))
 
         // matching header
-        let importers = CSVImporterManager.importers
+        let importers = CSVImporterFactory.importers
         for importer in importers {
             for header in importer.headers {
                 let url = temporaryFileURL()
                 createFile(at: url, content: "\(header.joined(separator: ", "))\n")
-                XCTAssertTrue(type(of: CSVImporterManager.new(ledger: nil, url: url)!) == importer)
+                XCTAssertTrue(type(of: CSVImporterFactory.new(ledger: nil, url: url)!) == importer)
             }
         }
     }
 
     func testNoEqualHeaders() {
         var headers = [[String]]()
-        let importers = CSVImporterManager.importers
+        let importers = CSVImporterFactory.importers
         for importer in importers {
             for header in importer.headers {
                 guard !headers.contains(header) else {

--- a/Tests/SwiftBeanCountImporterTests/FileImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/FileImporterTests.swift
@@ -15,12 +15,30 @@ final class FileImporterTests: XCTestCase {
 
     func testImporters() {
         // currently only csv files are supported
-        XCTAssertEqual(FileImporterManager.importers.count, CSVImporterManager.importers.count)
+        XCTAssertEqual(FileImporterFactory.importers.count, CSVImporterFactory.importers.count)
     }
 
     func testNew() {
         // no url
-        XCTAssertNil(FileImporterManager.new(ledger: nil, url: nil))
+        XCTAssertNil(FileImporterFactory.new(ledger: nil, url: nil))
+
+        // invalid URL
+        XCTAssertNil(FileImporterFactory.new(ledger: nil, url: URL(fileURLWithPath: "DOES_NOT_EXIST")))
+
+        // valid URL without matching headers
+        let url = temporaryFileURL()
+        createFile(at: url, content: "Header, no, matching, anything\n")
+        XCTAssertNil(FileImporterFactory.new(ledger: nil, url: url))
+
+        // matching header
+        let importers = CSVImporterFactory.importers
+        for importer in importers {
+            for header in importer.headers {
+                let url = temporaryFileURL()
+                createFile(at: url, content: "\(header.joined(separator: ", "))\n")
+                XCTAssertTrue(type(of: FileImporterFactory.new(ledger: nil, url: url)!) == importer)
+            }
+        }
     }
 
 }

--- a/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
@@ -28,8 +28,37 @@ private class TestImporter: Importer {
 
 final class ImporterTests: XCTestCase {
 
-    func testImporters() {
-        XCTAssertEqual(ImporterManager.importers.count, (FileImporterManager.importers + TextImporterManager.importers).count)
+    func testAllImporters() {
+        XCTAssertEqual(ImporterFactory.allImporters.count, (FileImporterFactory.importers + TextImporterFactory.importers).count)
+    }
+
+    func testFileImporter() {
+        // no url
+        XCTAssertNil(ImporterFactory.new(ledger: nil, url: nil))
+
+        // invalid URL
+        XCTAssertNil(ImporterFactory.new(ledger: nil, url: URL(fileURLWithPath: "DOES_NOT_EXIST")))
+
+        // valid URL without matching headers
+        let url = temporaryFileURL()
+        createFile(at: url, content: "Header, no, matching, anything\n")
+        XCTAssertNil(ImporterFactory.new(ledger: nil, url: url))
+
+        // matching header
+        let importers = CSVImporterFactory.importers
+        for importer in importers {
+            for header in importer.headers {
+                let url = temporaryFileURL()
+                createFile(at: url, content: "\(header.joined(separator: ", "))\n")
+                XCTAssertTrue(type(of: ImporterFactory.new(ledger: nil, url: url)!) == importer)
+            }
+        }
+    }
+
+     func testTextImporter() {
+        let result = ImporterFactory.new(ledger: nil, transaction: "", balance: "")
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result is ManuLifeImporter)
     }
 
     func testSettings() {

--- a/Tests/SwiftBeanCountImporterTests/TextImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/TextImporterTests.swift
@@ -12,8 +12,8 @@ import XCTest
 
 final class TextImporterTests: XCTestCase {
 
-    func testSettings() {
-        let result = TextImporterManager.new(ledger: nil, transaction: "", balance: "")
+    func testNew() {
+        let result = TextImporterFactory.new(ledger: nil, transaction: "", balance: "")
         XCTAssertNotNil(result)
         XCTAssertTrue(result is ManuLifeImporter)
     }


### PR DESCRIPTION
Only export ImporterFactory, instead of separate once for files and
text. Add test to fully test the creating of importers through all
factories.

Note: Breaking change

Fixes #38 