### PR TITLE
Unify Text and File Importers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ This is the importer of SwiftBeanCount. It reads files to create transactions. T
 
 ### Import Transactions
 
-1) Create a `FileImporter` via `ImporterFactory.new(ledger: Ledger?, url: URL?)` or a `Importer` via `ImporterFactory.new(ledger: Ledger?, transaction: String, balance: String)`, depending on what you want to import.
-2) Check `possibleAccounts()` on the importer. If there is more than one or none, promt to user to enter/select the account to use.
-3) Pass the result to the importer via `useAccount(name:)`.
-4) If using a FileImporter call `loadFile()`.
-5) If using a TextImporter, call `parse()` to get a string of the parsed transactions. If using a FileImporter, call `parseLineIntoTransaction()` to retrive transaction after transactions till it returns `nil`. It is recommended to allow the user the edit the transactions while doing this. (See [#2](https://github.com/Nef10/SwiftBeanCountImporter/issues/2))
+1) Create an `Importer` via either `ImporterFactory.new(ledger: Ledger?, url: URL?)` or `ImporterFactory.new(ledger: Ledger?, transaction: String, balance: String)`, depending on what you want to import.
+2) Call `load()` on the importer.
+3) Check `possibleAccounts()` on the importer. If there is more than one or none, promt to user to enter/select the account to use. To show the user for which import they are entering information, you can display `importName`.
+4) Pass the result to the importer via `useAccount(name:)`.
+5) Call `nextTransaction()` to retrive transaction after transactions till it returns `nil`. It is recommended to allow the user the edit the transactions while doing this. (See [#12](https://github.com/Nef10/SwiftBeanCountImporter/issues/12))
+6) Get `balancesToImport()` and `pricesToImport()` from the importer.
 
 ### Settings
 

--- a/Sources/SwiftBeanCountImporter/BaseImporter.swift
+++ b/Sources/SwiftBeanCountImporter/BaseImporter.swift
@@ -23,6 +23,10 @@ class BaseImporter: Importer {
         ledger?.accounts.first { $0.name == accountName }?.commoditySymbol ?? Settings.fallbackCommodity
     }
 
+    var importName: String {
+        "" // Override
+    }
+
     init(ledger: Ledger?) {
         self.ledger = ledger
     }
@@ -40,6 +44,22 @@ class BaseImporter: Importer {
 
     func accountsFromSettings() -> [AccountName] {
         (Self.get(setting: Self.accountsSetting) ?? "").components(separatedBy: CharacterSet(charactersIn: " ,")).map { try? AccountName($0) }.compactMap { $0 }
+    }
+
+    func load() {
+        // Override if neccessary
+    }
+
+    func nextTransaction() -> ImportedTransaction? {
+        nil // Override
+    }
+
+    func balancesToImport() -> [Balance] {
+        [] // Override if neccessary
+    }
+
+    func pricesToImport() -> [Price] {
+        [] // Override if neccessary
     }
 
 }

--- a/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
+++ b/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
@@ -29,6 +29,10 @@ class CSVBaseImporter: BaseImporter {
     let csvReader: CSVReader
     let fileName: String
 
+    override var importName: String {
+        fileName
+    }
+
     private var loaded = false
     private var lines = [CSVLine]()
 
@@ -38,7 +42,7 @@ class CSVBaseImporter: BaseImporter {
         super.init(ledger: ledger)
     }
 
-    func loadFile() {
+    override func load() {
         guard !loaded else {
             return
         }
@@ -49,7 +53,7 @@ class CSVBaseImporter: BaseImporter {
         loaded = true
     }
 
-    func parseLineIntoTransaction() -> ImportedTransaction? {
+    override func nextTransaction() -> ImportedTransaction? {
         guard let accountName = accountName else {
             fatalError("No account configured")
         }

--- a/Sources/SwiftBeanCountImporter/FileImporter.swift
+++ b/Sources/SwiftBeanCountImporter/FileImporter.swift
@@ -42,25 +42,6 @@ public struct ImportedTransaction {
 }
 
 /// Protocol to represent an Importer which imports a file
-public protocol FileImporter: Importer {
-
-    /// AccountName of the account the file belongs to
-    ///
-    /// You can use this to detect which posting the user should not edit
-    var accountName: AccountName? { get }
-
-    /// FileName of the file beeing imported
-    var fileName: String { get }
-
-    /// Loads the file into the memory
-    ///
-    /// You must call this method before you call `parseLineIntoTransaction()`.
-    /// You might want to show a loading indicator during the loading of large files.
-    func loadFile()
-
-    /// Parses the next line into an `ImportedTransaction`.
-    ///
-    /// Returns nil when there are no more lines left.
-    func parseLineIntoTransaction() -> ImportedTransaction?
+protocol FileImporter: Importer {
 
 }

--- a/Sources/SwiftBeanCountImporter/Importers/LunchOnUsImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/LunchOnUsImporter.swift
@@ -24,6 +24,10 @@ class LunchOnUsImporter: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "LunchOnUs File \(fileName)"
+    }
+
     override func parseLine() -> CSVLine {
         let date = Self.dateFormatter.date(from: csvReader[Self.date]!)!
         var description = ""

--- a/Sources/SwiftBeanCountImporter/Importers/N26Importer.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/N26Importer.swift
@@ -28,6 +28,10 @@ class N26Importer: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "N26 File \(fileName)"
+    }
+
     override func parseLine() -> CSVLine {
         let date = Self.dateFormatter.date(from: csvReader[Self.date]!)!
         let description = "\(csvReader[Self.recipient]!) \(csvReader[Self.description]!)"

--- a/Sources/SwiftBeanCountImporter/Importers/RBCImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/RBCImporter.swift
@@ -24,6 +24,10 @@ class RBCImporter: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "RBC File \(fileName)"
+    }
+
     override func parseLine() -> CSVLine {
         let date = Self.dateFormatter.date(from: csvReader[Self.date]!)!
         let description = csvReader[Self.description1]! + " " + csvReader[Self.description2]!

--- a/Sources/SwiftBeanCountImporter/Importers/RogersImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/RogersImporter.swift
@@ -33,6 +33,10 @@ class RogersImporter: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "Rogers Bank File \(fileName)"
+    }
+
     override func parseLine() -> CSVLine {
         let dateString = csvReader[Self.date1] ?? csvReader[Self.date2]!
         let date = Self.dateFormatter.date(from: dateString)!

--- a/Sources/SwiftBeanCountImporter/Importers/SimpliiImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/SimpliiImporter.swift
@@ -24,6 +24,10 @@ class SimpliiImporter: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "Simplii File \(fileName)"
+    }
+
     override func parseLine() -> CSVLine {
         let date = Self.dateFormatter.date(from: csvReader[Self.date]!)!
         let description = csvReader[Self.description]!

--- a/Sources/SwiftBeanCountImporter/Importers/TangerineAccountImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/TangerineAccountImporter.swift
@@ -28,6 +28,10 @@ class TangerineAccountImporter: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "Tangerine Account File \(fileName)"
+    }
+
     override func possibleAccountNames(for ledger: Ledger?) -> [AccountName] {
         if let accountName = accountName {
             return [accountName]

--- a/Sources/SwiftBeanCountImporter/Importers/TangerineCardImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/TangerineCardImporter.swift
@@ -23,6 +23,10 @@ class TangerineCardImporter: CSVBaseImporter, CSVImporter {
         return dateFormatter
     }()
 
+    override var importName: String {
+        "Tangerine Credit Card File \(fileName)"
+    }
+
     override func parseLine() -> CSVLine {
         let date = Self.dateFormatter.date(from: csvReader[Self.date]!)!
         var description = ""

--- a/Sources/SwiftBeanCountImporter/ParserUtils.swift
+++ b/Sources/SwiftBeanCountImporter/ParserUtils.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftBeanCountModel
 
 enum ParserUtils {
 
@@ -33,6 +34,11 @@ enum ParserUtils {
             exponent = afterDot.count
         }
         return (Decimal(sign: sign, exponent: -exponent, significand: Decimal(UInt64(amountString)!)), exponent)
+    }
+
+    static func parseAmountFrom(string: String, commoditySymbol: String) -> Amount {
+        let (number, decimalDigits) = ParserUtils.parseAmountDecimalFrom(string: string)
+        return Amount(number: number, commoditySymbol: commoditySymbol, decimalDigits: decimalDigits)
     }
 
 }

--- a/Sources/SwiftBeanCountImporter/TextImporter.swift
+++ b/Sources/SwiftBeanCountImporter/TextImporter.swift
@@ -35,9 +35,6 @@ protocol TransactionBalanceTextImporter: TextImporter {
 }
 
 /// Protocol to represent an Importer which imports text
-public protocol TextImporter: Importer {
-
-    /// Parses the input Strings into a String which can be added to the ledger
-    func parse() -> String
+protocol TextImporter: Importer {
 
 }

--- a/Tests/SwiftBeanCountImporterTests/BaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/BaseImporterTests.swift
@@ -22,6 +22,31 @@ final class BaseImporterTests: XCTestCase {
         XCTAssertEqual(BaseImporter.settingsName, "")
     }
 
+    func testLoad() {
+        let importer = BaseImporter(ledger: TestUtils.ledger)
+        importer.load()
+    }
+
+    func testImportName() {
+        let importer = BaseImporter(ledger: TestUtils.ledger)
+        XCTAssertEqual(importer.importName, "")
+    }
+
+    func testNextTransaction() {
+        let importer = BaseImporter(ledger: TestUtils.ledger)
+        XCTAssertNil(importer.nextTransaction())
+    }
+
+    func testBalancesToImport() {
+        let importer = BaseImporter(ledger: TestUtils.ledger)
+        XCTAssertTrue(importer.balancesToImport().isEmpty)
+    }
+
+    func testPricesToImport() {
+        let importer = BaseImporter(ledger: TestUtils.ledger)
+        XCTAssertTrue(importer.pricesToImport().isEmpty)
+    }
+
     func testSettings() {
         let settings = BaseImporter.settings
         XCTAssertEqual(settings.count, 1)

--- a/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
@@ -34,46 +34,49 @@ private class TestCSVBaseImporter: CSVBaseImporter {
 
 final class CSVBaseImporterTests: XCTestCase {
 
-    func testLoadFile() {
-        let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.basicCSVReader, fileName: "")
-        importer.useAccount(name: TestUtils.cash)
-        importer.loadFile()
+    func testImportName() {
+        let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.basicCSVReader, fileName: "ABCDTEST")
+        XCTAssertEqual(importer.importName, "ABCDTEST")
+    }
 
+    func testLoad() {
+        let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.basicCSVReader, fileName: "")
+        importer.load()
         // Can be called multiple times, still only returns each row once
-        importer.loadFile()
-        let line = importer.parseLineIntoTransaction()
-        XCTAssertNotNil(line)
+        importer.load()
+        importer.useAccount(name: TestUtils.cash)
 
-        let noLine = importer.parseLineIntoTransaction()
-        XCTAssertNil(noLine)
+        let importedTransaction = importer.nextTransaction()
+        XCTAssertNotNil(importedTransaction)
+
+        let noTransaction = importer.nextTransaction()
+        XCTAssertNil(noTransaction)
     }
 
-    func testLoadFileSortDate() {
+    func testLoadSortDate() {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.dateMixedCSVReader, fileName: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        importer.loadFile()
 
-        let line1 = importer.parseLineIntoTransaction()
-        XCTAssertNotNil(line1)
-        let line2 = importer.parseLineIntoTransaction()
-        XCTAssertNotNil(line2)
+        let importedTransaction1 = importer.nextTransaction()
+        XCTAssertNotNil(importedTransaction1)
+        let importedTransaction2 = importer.nextTransaction()
+        XCTAssertNotNil(importedTransaction2)
 
-        XCTAssertTrue(line1!.transaction.metaData.date < line2!.transaction.metaData.date)
+        XCTAssertTrue(importedTransaction1!.transaction.metaData.date < importedTransaction2!.transaction.metaData.date)
     }
 
-    func testParseLineIntoTransaction() {
+    func testNextTransaction() {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.basicCSVReader, fileName: "")
+
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
 
-        // nil when loadFile is not called beforehand
-        XCTAssertNil(importer.parseLineIntoTransaction())
+        let importedTransaction = importer.nextTransaction()
+        XCTAssertNotNil(importedTransaction)
 
-        importer.loadFile()
-        let line = importer.parseLineIntoTransaction()
-        XCTAssertNotNil(line)
-
-        let noLine = importer.parseLineIntoTransaction()
-        XCTAssertNil(noLine)
+        let noTransaction = importer.nextTransaction()
+        XCTAssertNil(noTransaction)
     }
 
     func testPrice() {
@@ -161,11 +164,11 @@ final class CSVBaseImporterTests: XCTestCase {
 
     private func transactionHelper(description: String, payee: String = "payee") -> Transaction {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.csvReader(description: description, payee: payee), fileName: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        importer.loadFile()
-        let line = importer.parseLineIntoTransaction()
-        XCTAssertNotNil(line)
-        return line!.transaction
+        let importedTransaction = importer.nextTransaction()
+        XCTAssertNotNil(importedTransaction)
+        return importedTransaction!.transaction
     }
 
 }

--- a/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
@@ -10,20 +10,9 @@ import Foundation
 import SwiftBeanCountModel
 import XCTest
 
-private class TestImporter: Importer {
-
+private class TestImporter: BaseImporter {
     static let setting = ImporterSetting(identifier: "accounts", name: "Account(s)")
-
-    class var settingsName: String { "" }
-    class var settings: [ImporterSetting] { [] }
-
-    func possibleAccountNames(for ledger: Ledger?) -> [AccountName] {
-        []
-    }
-
-    func useAccount(name: AccountName) {
-    }
-
+    override class var settings: [ImporterSetting] { [] }
 }
 
 final class ImporterTests: XCTestCase {

--- a/Tests/SwiftBeanCountImporterTests/Importers/LunchOnUsImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/LunchOnUsImporterTests.swift
@@ -20,6 +20,10 @@ final class LunchOnUsImporterTests: XCTestCase {
         XCTAssertEqual(LunchOnUsImporter.settingsName, "LunchOnUs Card")
     }
 
+    func testImportName() {
+        XCTAssertEqual(LunchOnUsImporter(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName, "LunchOnUs File TestName")
+    }
+
     func testParseLineNormalPurchase() {
         let importer = LunchOnUsImporter(ledger: nil,
                                          csvReader: TestUtils.csvReader(content: """

--- a/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
@@ -10,6 +10,65 @@ import Foundation
 @testable import SwiftBeanCountImporter
 import XCTest
 
+private let balance = """
+
+    Investment details
+
+    Current value:    $1,234.56
+
+    Breakdown by investments
+
+    1234 - ML Category Fund 9876 y8
+    Contribution category	Number	Unit
+    value	Current
+    value ($)
+
+    Employee Basic	8.0000	31.25	250.00
+    Employee voluntary	5.6000	31.25	175.00
+    Employer Basic	10.4000	31.25	325.00
+    Employer Match	8.0000	31.25	250.00
+
+    TOTAL	$1,000.00
+
+    5678 - ML Easy BB q9
+    Contribution category	Number	Unit
+    value	Current
+    value ($)
+
+    Employee Basic	11.7280	5.000	58.64
+    Employee voluntary	8.20960	5.000	41.05
+    Employer Basic	15.24640	5.000	76.23
+    Employer Match	11.72800	5.000	58.64
+
+    TOTAL	$234.56
+
+    """
+
+private let transaction = """
+
+    Transaction details
+    May 29, 2020 Contribution (Ref.# 12345678)
+
+    To:			Amount($)
+    ../Images/colour7.gif	 1234 ML Category Fund 9876 y8
+    Contribution 0.44112 units @ $21.221/unit	9.36
+    Total		9.36
+    ../Images/colour10.gif	 \(TestUtils.fundName)
+    Contribution 15.29544 units @ $9.148/unit	139.92
+    Total		139.92
+
+    """
+
+private let transactionInvalidDate = """
+    Transaction details
+    May -0, 2020 Contribution (Ref.# 12345678)
+
+    To:			Amount($)
+    ../Images/colour7.gif	 1234 ML Category Fund 9876 y8
+    Contribution 0.44112 units @ $21.221/unit	9.36
+    Total		9.36
+    """
+
 final class ManuLifeImporterTests: XCTestCase {
 
     private static let printDateFormatter: DateFormatter = {
@@ -23,94 +82,40 @@ final class ManuLifeImporterTests: XCTestCase {
         Self.printDateFormatter.string(from: Date())
     }()
 
-    private let balance = """
-
-        Investment details
-
-        Current value:    $1,234.56
-
-        Breakdown by investments
-
-        1234 - ML Category Fund 9876 y8
-        Contribution category	Number	Unit
-        value	Current
-        value ($)
-
-        Employee Basic	8.0000	31.25	250.00
-        Employee voluntary	5.6000	31.25	175.00
-        Employer Basic	10.4000	31.25	325.00
-        Employer Match	8.0000	31.25	250.00
-
-        TOTAL	$1,000.00
-
-        5678 - ML Easy BB q9
-        Contribution category	Number	Unit
-        value	Current
-        value ($)
-
-        Employee Basic	11.7280	5.000	58.64
-        Employee voluntary	8.20960	5.000	41.05
-        Employer Basic	15.24640	5.000	76.23
-        Employer Match	11.72800	5.000	58.64
-
-        TOTAL	$234.56
-
-        """
-
-    private let transaction = """
-
-        Transaction details
-        May 29, 2020 Contribution (Ref.# 12345678)
-
-        To:			Amount($)
-        ../Images/colour7.gif	 1234 ML Category Fund 9876 y8
-        Contribution 0.44112 units @ $21.221/unit	9.36
-        Total		9.36
-        ../Images/colour10.gif	 \(TestUtils.fundName)
-        Contribution 15.29544 units @ $9.148/unit	139.92
-        Total		139.92
-
-        """
-
-    private let transactionInvalidDate = """
-        Transaction details
-        May -0, 2020 Contribution (Ref.# 12345678)
-
-        To:			Amount($)
-        ../Images/colour7.gif	 1234 ML Category Fund 9876 y8
-        Contribution 0.44112 units @ $21.221/unit	9.36
-        Total		9.36
-        """
-
     private lazy var balanceResult: String = { """
-        \(dateString) balance Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8                 8.0000 1234 ML Category Fund 9876 y8
-        \(dateString) balance Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8                10.4000 1234 ML Category Fund 9876 y8
-        \(dateString) balance Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8                 8.0000 1234 ML Category Fund 9876 y8
-        \(dateString) balance Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8             5.6000 1234 ML Category Fund 9876 y8
-        \(dateString) balance Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol)                                         11.7280 \(TestUtils.fundSymbol)
-        \(dateString) balance Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol)                                        15.24640 \(TestUtils.fundSymbol)
-        \(dateString) balance Assets:Cash:Employer:Match:\(TestUtils.fundSymbol)                                        11.72800 \(TestUtils.fundSymbol)
-        \(dateString) balance Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol)                                     8.20960 \(TestUtils.fundSymbol)
+        \(dateString) balance Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8 8.0000 1234 ML Category Fund 9876 y8
+        \(dateString) balance Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8 10.4000 1234 ML Category Fund 9876 y8
+        \(dateString) balance Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8 8.0000 1234 ML Category Fund 9876 y8
+        \(dateString) balance Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8 5.6000 1234 ML Category Fund 9876 y8
+        \(dateString) balance Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol) 11.7280 \(TestUtils.fundSymbol)
+        \(dateString) balance Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol) 15.24640 \(TestUtils.fundSymbol)
+        \(dateString) balance Assets:Cash:Employer:Match:\(TestUtils.fundSymbol) 11.72800 \(TestUtils.fundSymbol)
+        \(dateString) balance Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol) 8.20960 \(TestUtils.fundSymbol)
+        """
+    }()
 
-        \(dateString) price 1234 ML Category Fun 31.25 USD
-        \(dateString) price \(TestUtils.fundSymbol)                 5.000 USD
+    private lazy var balancePricesResult: String = { """
+        \(dateString) price 1234 ML Category Fund 9876 y8 31.25 USD
+        \(dateString) price \(TestUtils.fundSymbol) 5.000 USD
         """
     }()
 
     private let transactionResult = """
         2020-05-29 * "" ""
-          Assets:Cash:Parking                                                 149.28    USD
-          Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-          Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-          Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-          Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8          0.11028 1234 ML Category Fun {21.221 USD}
-          Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
-          Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
-          Assets:Cash:Employer:Match:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
-          Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol)                                   3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
+          Assets:Cash:Parking 149.28 USD
+          Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+          Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+          Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+          Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+          Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+          Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+          Assets:Cash:Employer:Match:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+          Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+        """
 
-        2020-05-29 price 1234 ML Category Fun 21.221 USD
-        2020-05-29 price \(TestUtils.fundSymbol)                 9.148 USD
+    private let transactionPricesResult = """
+        2020-05-29 price 1234 ML Category Fund 9876 y8 21.221 USD
+        2020-05-29 price \(TestUtils.fundSymbol) 9.148 USD
         """
 
     func testSettingsName() {
@@ -121,27 +126,72 @@ final class ManuLifeImporterTests: XCTestCase {
         XCTAssertEqual(ManuLifeImporter.settings.count, 6)
     }
 
+    func testImportName() {
+        XCTAssertEqual(ManuLifeImporter(ledger: nil, transaction: "", balance: "").importName, "ManuLife Text")
+    }
+
     func testParseEmpty() {
         let importer = ManuLifeImporter(ledger: nil, transaction: "", balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, "")
+        XCTAssertNil(importer.nextTransaction())
+        XCTAssertEqual(importer.balancesToImport(), [])
+        XCTAssertEqual(importer.pricesToImport(), [])
     }
 
     func testParseBalance() {
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: "", balance: balance)
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, balanceResult)
+        XCTAssertNil(importer.nextTransaction())
+        let balances = importer.balancesToImport()
+        let prices = importer.pricesToImport()
+        XCTAssertEqual(balances.count, 8)
+        XCTAssertEqual(prices.count, 2)
+
+        XCTAssertEqual(
+            "\(balances.map { "\($0)" }.joined(separator: "\n"))\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))",
+            "\(balanceResult)\n\n\(balancePricesResult)"
+        )
     }
 
     func testTransaction() {
         clearSettings()
 
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, transactionResult) // Note: End of long symbol in transaction cut off (#4)
+        let transaction = importer.nextTransaction()
+        XCTAssertNotNil(transaction)
+        XCTAssertEqual(transaction!.originalDescription, "")
+        XCTAssertNil(importer.nextTransaction())
+        let prices = importer.pricesToImport()
+        XCTAssertTrue(importer.balancesToImport().isEmpty)
+        XCTAssertEqual(prices.count, 2)
+
+        XCTAssertEqual(
+            "\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))",
+            "\(transactionResult)\n\n\(transactionPricesResult)"
+        )
+    }
+
+    func testBalanceAndTransaction() {
+        clearSettings()
+        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: balance)
+        importer.load()
+        importer.useAccount(name: TestUtils.cash)
+        let transaction = importer.nextTransaction()
+        XCTAssertNotNil(transaction)
+        XCTAssertEqual(transaction!.originalDescription, "")
+        XCTAssertNil(importer.nextTransaction())
+        let balances = importer.balancesToImport()
+        let prices = importer.pricesToImport()
+        XCTAssertEqual(balances.count, 8)
+        XCTAssertEqual(prices.count, 4)
+        XCTAssertEqual(
+            "\(transaction!.transaction)\n\n\(balances.map { "\($0)" }.joined(separator: "\n"))\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))",
+            "\(transactionResult)\n\n\(balanceResult)\n\n\(transactionPricesResult)\n\(balancePricesResult)"
+        )
     }
 
     func testTransactionSettings() {
@@ -152,23 +202,29 @@ final class ManuLifeImporterTests: XCTestCase {
         ManuLifeImporter.set(setting: ManuLifeImporter.cashAccountSetting, to: "Setting")
 
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, """
+        let transaction = importer.nextTransaction()
+        XCTAssertNotNil(transaction)
+        XCTAssertEqual(transaction!.originalDescription, "")
+        XCTAssertNil(importer.nextTransaction())
+        XCTAssertTrue(importer.balancesToImport().isEmpty)
+        let prices = importer.pricesToImport()
+        XCTAssertEqual("\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))", """
             2020-05-29 * "" ""
-              Assets:Cash:Setting                                                 149.28    USD
-              Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8              0.14336 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8          0.07720 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
-              Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol)                                       4.97102 \(TestUtils.fundSymbol)                 {9.148 USD}
-              Assets:Cash:Employer:Match:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
-              Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol)                                   2.67670 \(TestUtils.fundSymbol)                 {9.148 USD}
+              Assets:Cash:Setting 149.28 USD
+              Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8 0.14336 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8 0.07720 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+              Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol) 4.97102 \(TestUtils.fundSymbol) {9.148 USD}
+              Assets:Cash:Employer:Match:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+              Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol) 2.67670 \(TestUtils.fundSymbol) {9.148 USD}
 
-            2020-05-29 price 1234 ML Category Fun 21.221 USD
-            2020-05-29 price \(TestUtils.fundSymbol)                 9.148 USD
-            """) // Note: End of long symbol in transaction cut off (#4)
+            2020-05-29 price 1234 ML Category Fund 9876 y8 21.221 USD
+            2020-05-29 price \(TestUtils.fundSymbol) 9.148 USD
+            """)
 
         clearSettings()
     }
@@ -181,21 +237,28 @@ final class ManuLifeImporterTests: XCTestCase {
         ManuLifeImporter.set(setting: ManuLifeImporter.cashAccountSetting, to: "Setting")
 
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, """
+        let transaction = importer.nextTransaction()
+        XCTAssertNotNil(transaction)
+        XCTAssertEqual(transaction!.originalDescription, "")
+        XCTAssertNil(importer.nextTransaction())
+        XCTAssertTrue(importer.balancesToImport().isEmpty)
+        let prices = importer.pricesToImport()
+        XCTAssertEqual(prices.count, 2)
+        XCTAssertEqual("\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))", """
             2020-05-29 * "" ""
-              Assets:Cash:Setting                                                 149.28    USD
-              Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8              0.22056 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8              0.11028 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
-              Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol)                                       7.64772 \(TestUtils.fundSymbol)                 {9.148 USD}
-              Assets:Cash:Employer:Match:\(TestUtils.fundSymbol)                                       3.82386 \(TestUtils.fundSymbol)                 {9.148 USD}
+              Assets:Cash:Setting 149.28 USD
+              Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8 0.22056 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employee:Basic:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
+              Assets:Cash:Employer:Basic:\(TestUtils.fundSymbol) 7.64772 \(TestUtils.fundSymbol) {9.148 USD}
+              Assets:Cash:Employer:Match:\(TestUtils.fundSymbol) 3.82386 \(TestUtils.fundSymbol) {9.148 USD}
 
-            2020-05-29 price 1234 ML Category Fun 21.221 USD
-            2020-05-29 price \(TestUtils.fundSymbol)                 9.148 USD
-            """) // Note: End of long symbol in transaction cut off (#4)
+            2020-05-29 price 1234 ML Category Fund 9876 y8 21.221 USD
+            2020-05-29 price \(TestUtils.fundSymbol) 9.148 USD
+            """)
 
         clearSettings()
     }
@@ -208,41 +271,43 @@ final class ManuLifeImporterTests: XCTestCase {
         ManuLifeImporter.set(setting: ManuLifeImporter.cashAccountSetting, to: "Setting")
 
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, """
+        let transaction = importer.nextTransaction()
+        XCTAssertNotNil(transaction)
+        XCTAssertEqual(transaction!.originalDescription, "")
+        XCTAssertNil(importer.nextTransaction())
+        XCTAssertTrue(importer.balancesToImport().isEmpty)
+        let prices = importer.pricesToImport()
+        XCTAssertEqual("\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))", """
             2020-05-29 * "" ""
-              Assets:Cash:Setting                                                 149.28    USD
-              Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8          0.44112 1234 ML Category Fun {21.221 USD}
-              Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol)                                   15.29544 \(TestUtils.fundSymbol)                 {9.148 USD}
+              Assets:Cash:Setting 149.28 USD
+              Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8 0.44112 1234 ML Category Fund 9876 y8 {21.221 USD}
+              Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol) 15.29544 \(TestUtils.fundSymbol) {9.148 USD}
 
-            2020-05-29 price 1234 ML Category Fun 21.221 USD
-            2020-05-29 price \(TestUtils.fundSymbol)                 9.148 USD
-            """) // Note: End of long symbol in transaction cut off (#4)
+            2020-05-29 price 1234 ML Category Fund 9876 y8 21.221 USD
+            2020-05-29 price \(TestUtils.fundSymbol) 9.148 USD
+            """)
 
         clearSettings()
     }
 
     func testTransactionGarbage() {
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: "This is not a valid Transaction", balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, "")
+        XCTAssertNil(importer.nextTransaction())
+        XCTAssertEqual(importer.balancesToImport(), [])
+        XCTAssertEqual(importer.pricesToImport(), [])
     }
 
     func testTransactionInvalidData() {
         let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transactionInvalidDate, balance: "")
+        importer.load()
         importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result.components(separatedBy: "\n").first, #"* "" """#)
-    }
-
-    func testBalanceAndTransaction() {
-        clearSettings()
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: balance)
-        importer.useAccount(name: TestUtils.cash)
-        let result = importer.parse()
-        XCTAssertEqual(result, "\(transactionResult)\n\n\(balanceResult)") // Note: End of long symbol in transaction cut off (#4)
+        XCTAssertNil(importer.nextTransaction())
+        XCTAssertEqual(importer.balancesToImport(), [])
+        XCTAssertEqual(importer.pricesToImport(), [])
     }
 
     private func clearSettings() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/N26ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/N26ImporterTests.swift
@@ -33,6 +33,10 @@ final class N26ImporterTests: XCTestCase {
         XCTAssertEqual(N26Importer.settingsName, "N26")
     }
 
+    func testImportName() {
+        XCTAssertEqual(N26Importer(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName, "N26 File TestName")
+    }
+
     func testParseLineNormalPurchase() {
         let importer = N26Importer(ledger: nil,
                                    csvReader: TestUtils.csvReader(content: """

--- a/Tests/SwiftBeanCountImporterTests/Importers/RBCImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/RBCImporterTests.swift
@@ -21,6 +21,10 @@ final class RBCImporterTests: XCTestCase {
         XCTAssertEqual(RBCImporter.settingsName, "RBC Accounts + CC")
     }
 
+    func testImportName() {
+        XCTAssertEqual(RBCImporter(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName, "RBC File TestName")
+    }
+
     func testParseLineAccount() {
         let importer = RBCImporter(ledger: nil,
                                    csvReader: TestUtils.csvReader(content: """

--- a/Tests/SwiftBeanCountImporterTests/Importers/RogersImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/RogersImporterTests.swift
@@ -29,6 +29,10 @@ final class RogersImporterTests: XCTestCase {
         XCTAssertEqual(RogersImporter.settingsName, "Rogers CC")
     }
 
+    func testImportName() {
+        XCTAssertEqual(RogersImporter(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName, "Rogers Bank File TestName")
+    }
+
     func testParseLine1() {
         let importer = RogersImporter(ledger: nil,
                                       csvReader: TestUtils.csvReader(content: """

--- a/Tests/SwiftBeanCountImporterTests/Importers/SimpliiImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/SimpliiImporterTests.swift
@@ -20,6 +20,10 @@ final class SimpliiImporterTests: XCTestCase {
         XCTAssertEqual(SimpliiImporter.settingsName, "Simplii Accounts")
     }
 
+    func testImportName() {
+        XCTAssertEqual(SimpliiImporter(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName, "Simplii File TestName")
+    }
+
     func testParseLine() {
         let importer = SimpliiImporter(ledger: nil,
                                        csvReader: TestUtils.csvReader(content: """

--- a/Tests/SwiftBeanCountImporterTests/Importers/TangerineAccountImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/TangerineAccountImporterTests.swift
@@ -21,6 +21,10 @@ final class TangerineAccountImporterTests: XCTestCase {
         XCTAssertEqual(TangerineAccountImporter.settingsName, "Tangerine Accounts")
     }
 
+    func testImportName() {
+        XCTAssertEqual(TangerineAccountImporter(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName, "Tangerine Account File TestName")
+    }
+
     func testPossibleAccountNames() {
         let key = TangerineAccountImporter.getUserDefaultsKey(for: TangerineAccountImporter.accountsSetting)
         UserDefaults.standard.set("\(TestUtils.cash.fullName), \(TestUtils.chequing.fullName)", forKey: key)

--- a/Tests/SwiftBeanCountImporterTests/Importers/TangerineCardImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/TangerineCardImporterTests.swift
@@ -21,6 +21,13 @@ final class TangerineCardImporterTests: XCTestCase {
         XCTAssertEqual(TangerineCardImporter.settingsName, "Tangerine CC")
     }
 
+    func testImportName() {
+        XCTAssertEqual(
+            TangerineCardImporter(ledger: nil, csvReader: TestUtils.csvReader(content: "A"), fileName: "TestName").importName,
+            "Tangerine Credit Card File TestName"
+        )
+    }
+
     func testParseLine() {
         let importer = TangerineCardImporter(ledger: nil,
                                              csvReader: TestUtils.csvReader(content: """

--- a/Tests/SwiftBeanCountImporterTests/ParserUtilsTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/ParserUtilsTests.swift
@@ -37,4 +37,38 @@ class ParserUtilsTests: XCTestCase {
         XCTAssertEqual(decimalDigits, 2)
     }
 
+    func testParseAmountFrom() {
+        let commoditySymbol = "ABC"
+
+        var amount = ParserUtils.parseAmountFrom(string: "1", commoditySymbol: commoditySymbol)
+        XCTAssertEqual(amount.number, Decimal(1))
+        XCTAssertEqual(amount.decimalDigits, 0)
+        XCTAssertEqual(amount.commoditySymbol, commoditySymbol)
+
+        amount = ParserUtils.parseAmountFrom(string: "0.00", commoditySymbol: commoditySymbol)
+        XCTAssertEqual(amount.number, Decimal(0))
+        XCTAssertEqual(amount.decimalDigits, 2)
+        XCTAssertEqual(amount.commoditySymbol, commoditySymbol)
+
+        amount = ParserUtils.parseAmountFrom(string: "+3.0", commoditySymbol: commoditySymbol)
+        XCTAssertEqual(amount.number, Decimal(3))
+        XCTAssertEqual(amount.decimalDigits, 1)
+        XCTAssertEqual(amount.commoditySymbol, commoditySymbol)
+
+        amount = ParserUtils.parseAmountFrom(string: "-10.0000", commoditySymbol: commoditySymbol)
+        XCTAssertEqual(amount.number, Decimal(-10))
+        XCTAssertEqual(amount.decimalDigits, 4)
+        XCTAssertEqual(amount.commoditySymbol, commoditySymbol)
+
+        amount = ParserUtils.parseAmountFrom(string: "1.25", commoditySymbol: commoditySymbol)
+        XCTAssertEqual(amount.number, Decimal(1.25))
+        XCTAssertEqual(amount.decimalDigits, 2)
+        XCTAssertEqual(amount.commoditySymbol, commoditySymbol)
+
+        amount = ParserUtils.parseAmountFrom(string: "1,001.25", commoditySymbol: commoditySymbol)
+        XCTAssertEqual(amount.number, Decimal(1_001.25))
+        XCTAssertEqual(amount.decimalDigits, 2)
+        XCTAssertEqual(amount.commoditySymbol, commoditySymbol)
+    }
+
 }


### PR DESCRIPTION
Both now:
- Return SwiftBeanCountModel objects (instead of the text importer
    returning a string)
- Both now have a load method (instead of loadFile only for FileImporters)
- Both output transaction after transaction via nextTransaction (instead
    of only the FileImporters via parseLineIntoTransaction)
- Both now can return balances and prices (instead of only the TextImporters)
- Both now have a import name (instead of fileName only for FileImporters)

Other changes:
- Load now needs to be called before possibleAccounts
- The ImporterFactory now returns only Importer types instead of specific
    file or text subclasses

Note: This is a breaking change

Fixes #2
Fixes #4