### PR TITLE
Wrap usage of UserDefaults into a Storage protocol

### DIFF
--- a/Sources/SwiftBeanCountImporter/Settings.swift
+++ b/Sources/SwiftBeanCountImporter/Settings.swift
@@ -8,23 +8,41 @@
 
 import Foundation
 
+/// Protocol to define a storage for the settings
+public protocol SettingsStorage {
+
+    /// Saves a value for a key
+    func set(_ value: Any?, forKey defaultName: String)
+
+    /// Gets a saved string for a given key
+    func string(forKey defaultName: String) -> String?
+
+    /// Gets a saved dictionary for a given key
+    func dictionary(forKey defaultName: String) -> [String: Any]?
+}
+
 /// Constants releated to settings of the importer
 public enum Settings {
 
-    /// `UserDefaults` key for the payee mapping
-    static let payeesUserDefaultKey = "payees"
-    /// `UserDefaults` key for the account mapping
-    static let accountsUserDefaultsKey = "accounts"
-    /// `UserDefaults` key for the description mapping
-    static let descriptionUserDefaultsKey = "description"
-    /// `UserDefaults` key for the date tolerance to detect duplicate transactions
-    static let dateToleranceUserDefaultsKey = "date_tolerance"
+    /// Storage key for the payee mapping
+    static let payeesKey = "payees"
+    /// Storage key for the account mapping
+    static let accountsKey = "accounts"
+    /// Storage key for the description mapping
+    static let descriptionKey = "description"
+    /// Storage key for the date tolerance to detect duplicate transactions
+    static let dateToleranceKey = "date_tolerance"
 
     /// Default date tolerance to detect duplicate transactions
     static let defaultDateTolerance = 2 // days
 
     static let defaultAccountName = "Expenses:TODO"
     static let fallbackCommodity = "CAD"
+
+    /// A Storage which saves the settings
+    ///
+    /// Default value is `UserDefaults.standard`
+    public static var storage: SettingsStorage = UserDefaults.standard
 
     /// Mappings of descriptions the user saved when importing previous transactions
     ///
@@ -34,7 +52,7 @@ public enum Settings {
     /// Keys are the original descriptions from the importer and the value are the new descriptions
     /// the user mapped them to
     public static var allDescriptionMappings: [String: String] {
-        UserDefaults.standard.dictionary(forKey: descriptionUserDefaultsKey) as? [String: String] ?? [:]
+       storage.dictionary(forKey: descriptionKey) as? [String: String] ?? [:]
     }
 
     /// Mappings of payees the user saved when importing previous transactions
@@ -45,7 +63,7 @@ public enum Settings {
     /// Keys are the original descriptions from the importer and the values are the new payees
     /// the user mapped them to
     public static var allPayeeMappings: [String: String] {
-        UserDefaults.standard.dictionary(forKey: payeesUserDefaultKey) as? [String: String] ?? [:]
+        storage.dictionary(forKey: payeesKey) as? [String: String] ?? [:]
     }
 
     /// Mappings of accounts the user saved when importing previous transactions
@@ -55,7 +73,7 @@ public enum Settings {
     ///
     /// Keys are payees and the values are account name strings the user mapped them to
     public static var allAccountMappings: [String: String] {
-        UserDefaults.standard.dictionary(forKey: accountsUserDefaultsKey) as? [String: String] ?? [:]
+        storage.dictionary(forKey: accountsKey) as? [String: String] ?? [:]
     }
 
     // Date tolerance to check for duplicate transactions when importing
@@ -70,14 +88,14 @@ public enum Settings {
     /// See also `dateTolerance` which offers this value as `TimeInterval`
     public static var dateToleranceInDays: Int {
         get {
-            if let daysString = UserDefaults.standard.string(forKey: Settings.dateToleranceUserDefaultsKey), let days = Int(daysString) {
+            if let daysString = storage.string(forKey: Settings.dateToleranceKey), let days = Int(daysString) {
                 return days
             }
             return defaultDateTolerance
         }
         set(newValue) {
             // the string conversion is a workaround for https://bugs.swift.org/plugins/servlet/mobile#issue/SR-15124
-            UserDefaults.standard.set("\(newValue)", forKey: dateToleranceUserDefaultsKey)
+            storage.set("\(newValue)", forKey: dateToleranceKey)
         }
     }
 
@@ -92,9 +110,9 @@ public enum Settings {
     ///   - key: original description of the imported transaction
     ///   - description: new description - Use nil to delete a mapping.
     public static func setDescriptionMapping(key: String, description: String?) {
-        var desciptions = UserDefaults.standard.dictionary(forKey: descriptionUserDefaultsKey) as? [String: String] ?? [:]
+        var desciptions = storage.dictionary(forKey: descriptionKey) as? [String: String] ?? [:]
         desciptions[key] = description
-        UserDefaults.standard.set(desciptions, forKey: descriptionUserDefaultsKey)
+        storage.set(desciptions, forKey: descriptionKey)
     }
 
     /// Save a new mapping of a payee the user wants to automatically apply to
@@ -108,9 +126,9 @@ public enum Settings {
     ///   - key: original description of an imported transaction
     ///   - payee: payee to map transactions with this description to. Use nil to delete a mapping.
     public static func setPayeeMapping(key: String, payee: String?) {
-        var payees = UserDefaults.standard.dictionary(forKey: payeesUserDefaultKey) as? [String: String] ?? [:]
+        var payees = storage.dictionary(forKey: payeesKey) as? [String: String] ?? [:]
         payees[key] = payee
-        UserDefaults.standard.set(payees, forKey: payeesUserDefaultKey)
+       storage.set(payees, forKey: payeesKey)
     }
 
     /// Save a new mapping of an account the user wants to automatically apply to
@@ -124,9 +142,12 @@ public enum Settings {
     ///   - key: payee
     ///   - account: account name string - Use nil to delete a mapping
     public static func setAccountMapping(key: String, account: String?) {
-        var accounts = UserDefaults.standard.dictionary(forKey: accountsUserDefaultsKey) as? [String: String] ?? [:]
+        var accounts = storage.dictionary(forKey: accountsKey) as? [String: String] ?? [:]
         accounts[key] = account
-        UserDefaults.standard.set(accounts, forKey: accountsUserDefaultsKey)
+        storage.set(accounts, forKey: accountsKey)
     }
 
+}
+
+extension UserDefaults: SettingsStorage {
 }

--- a/Tests/SwiftBeanCountImporterTests/BaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/BaseImporterTests.swift
@@ -102,38 +102,32 @@ final class BaseImporterTests: XCTestCase {
     func testSavedPayee() {
         let description = "abcd"
         let payeeMapping = "efg"
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([description: payeeMapping], forKey: Settings.payeesUserDefaultKey)
+        Settings.setPayeeMapping(key: description, payee: payeeMapping)
         let importer = BaseImporter(ledger: TestUtils.ledger)
         let (_, savedPayee) = importer.savedDescriptionAndPayeeFor(description: description)
         XCTAssertEqual(savedPayee, payeeMapping)
-
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
     }
 
     func testSavedDescription() {
         let description = "abcd"
         let descriptionMapping = "efg"
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([description: descriptionMapping], forKey: Settings.descriptionUserDefaultsKey)
+        Settings.setDescriptionMapping(key: description, description: descriptionMapping)
         let importer = BaseImporter(ledger: TestUtils.ledger)
         let (savedDescription, _) = importer.savedDescriptionAndPayeeFor(description: description)
         XCTAssertEqual(savedDescription, descriptionMapping)
-
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
     }
 
     func testSavedAccount() {
         let payee = "abcd"
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([payee: TestUtils.chequing.fullName], forKey: Settings.accountsUserDefaultsKey)
+        Settings.setAccountMapping(key: payee, account: TestUtils.chequing.fullName)
         let importer = BaseImporter(ledger: TestUtils.ledger)
         XCTAssertEqual(importer.savedAccountNameFor(payee: payee), TestUtils.chequing)
-
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
     }
 
     func testSanitizeDescription() {

--- a/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
@@ -97,47 +97,37 @@ final class CSVBaseImporterTests: XCTestCase {
     func testSavedPayee() {
         let description = "abcd"
         let payeeMapping = "efg"
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([description: payeeMapping], forKey: Settings.payeesUserDefaultKey)
+        Settings.setPayeeMapping(key: description, payee: payeeMapping)
         XCTAssertEqual(transactionHelper(description: description).metaData.payee, payeeMapping)
-
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
     }
 
     func testSavedDescription() {
         let description = "abcd"
         let descriptionMapping = "efg"
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([description: descriptionMapping], forKey: Settings.descriptionUserDefaultsKey)
+        Settings.setDescriptionMapping(key: description, description: descriptionMapping)
         XCTAssertEqual(descriptionHelper(description: description), descriptionMapping)
-
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
     }
 
     func testSavedAccount() {
         let payee = "abcd"
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([payee: TestUtils.chequing.fullName], forKey: Settings.accountsUserDefaultsKey)
+        Settings.setAccountMapping(key: payee, account: TestUtils.chequing.fullName)
         XCTAssertEqual(transactionHelper(description: "", payee: payee).postings.first { $0.accountName != TestUtils.cash }?.accountName, TestUtils.chequing)
-
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
     }
 
     func testSavedPayeeAccount() {
         let description = "abcd"
         let payee = "efg"
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
+        Settings.storage = TestStorage()
 
-        UserDefaults.standard.set([payee: TestUtils.chequing.fullName], forKey: Settings.accountsUserDefaultsKey)
-        UserDefaults.standard.set([description: payee], forKey: Settings.payeesUserDefaultKey)
+        Settings.setAccountMapping(key: payee, account: TestUtils.chequing.fullName)
+        Settings.setPayeeMapping(key: description, payee: payee)
         XCTAssertEqual(transactionHelper(description: description).postings.first { $0.accountName != TestUtils.cash }?.accountName, TestUtils.chequing)
-
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
     }
 
     func testSanitizeDescription() {

--- a/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
@@ -63,6 +63,8 @@ final class ImporterTests: XCTestCase {
         let description = "ab"
         let payee = "ef"
         let accountName = TestUtils.cash
+        Settings.storage = TestStorage()
+
         let metaData = TransactionMetaData(date: Date(),
                                            payee: "",
                                            narration: originalDescription,
@@ -77,15 +79,11 @@ final class ImporterTests: XCTestCase {
         let transaction = Transaction(metaData: metaData, postings: [posting1, posting2])
         let importedTransaction = ImportedTransaction(transaction: transaction, originalDescription: originalDescription)
 
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
-
         importedTransaction.saveMapped(description: description, payee: payee, accountName: accountName)
 
-        XCTAssertEqual(UserDefaults.standard.object(forKey: Settings.descriptionUserDefaultsKey) as? [String: String], [originalDescription: description])
-        XCTAssertEqual(UserDefaults.standard.object(forKey: Settings.payeesUserDefaultKey) as? [String: String], [originalDescription: payee])
-        XCTAssertEqual(UserDefaults.standard.object(forKey: Settings.accountsUserDefaultsKey) as? [String: String], [payee: accountName.fullName])
+        XCTAssertEqual(Settings.allDescriptionMappings, [originalDescription: description])
+        XCTAssertEqual(Settings.allPayeeMappings, [originalDescription: payee])
+        XCTAssertEqual(Settings.allAccountMappings, [payee: accountName.fullName])
     }
 
 }

--- a/Tests/SwiftBeanCountImporterTests/SettingsTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/SettingsTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class SettingsTests: XCTestCase {
 
     func testDescriptionMappings() {
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
+        Settings.storage = TestStorage()
 
         XCTAssertEqual(Settings.allDescriptionMappings, [:])
 
@@ -32,12 +32,10 @@ final class SettingsTests: XCTestCase {
         // delete
         Settings.setDescriptionMapping(key: "originalDescription2", description: nil)
         XCTAssertEqual(Settings.allDescriptionMappings, ["originalDescription": "newer one"])
-
-        UserDefaults.standard.removeObject(forKey: Settings.descriptionUserDefaultsKey)
     }
 
     func testPayeeMappings() {
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
+        Settings.storage = TestStorage()
 
         XCTAssertEqual(Settings.allPayeeMappings, [:])
 
@@ -56,12 +54,10 @@ final class SettingsTests: XCTestCase {
         // delete
         Settings.setPayeeMapping(key: "originalDescription2", payee: nil)
         XCTAssertEqual(Settings.allPayeeMappings, ["originalDescription": "newer one"])
-
-        UserDefaults.standard.removeObject(forKey: Settings.payeesUserDefaultKey)
     }
 
     func testAccountMappings() {
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
+        Settings.storage = TestStorage()
 
         XCTAssertEqual(Settings.allAccountMappings, [:])
 
@@ -80,12 +76,10 @@ final class SettingsTests: XCTestCase {
         // delete
         Settings.setAccountMapping(key: "originalDescription2", account: nil)
         XCTAssertEqual(Settings.allAccountMappings, ["originalDescription": "newer one"])
-
-        UserDefaults.standard.removeObject(forKey: Settings.accountsUserDefaultsKey)
     }
 
     func testDateTolerance() {
-        UserDefaults.standard.removeObject(forKey: Settings.dateToleranceUserDefaultsKey)
+        Settings.storage = TestStorage()
 
         XCTAssertEqual(Settings.dateToleranceInDays, Settings.defaultDateTolerance)
         XCTAssertEqual(Settings.dateTolerance, Double(Settings.defaultDateTolerance * 60 * 60 * 24))
@@ -93,8 +87,6 @@ final class SettingsTests: XCTestCase {
         Settings.dateToleranceInDays = 4
         XCTAssertEqual(Settings.dateToleranceInDays, 4)
         XCTAssertEqual(Settings.dateTolerance, Double(4 * 60 * 60 * 24))
-
-        UserDefaults.standard.removeObject(forKey: Settings.dateToleranceUserDefaultsKey)
     }
 
 }

--- a/Tests/SwiftBeanCountImporterTests/TestUtils.swift
+++ b/Tests/SwiftBeanCountImporterTests/TestUtils.swift
@@ -8,8 +8,26 @@
 
 import CSV
 import Foundation
+@testable import SwiftBeanCountImporter
 import SwiftBeanCountModel
 import XCTest
+
+class TestStorage: SettingsStorage {
+
+    var storage = [String: Any]()
+
+    func set(_ value: Any?, forKey defaultName: String) {
+        storage[defaultName] = value
+    }
+
+    func string(forKey defaultName: String) -> String? {
+        storage[defaultName] as? String
+    }
+
+    func dictionary(forKey defaultName: String) -> [String: Any]? {
+        storage[defaultName] as? [String: Any]
+    }
+}
 
 enum TestUtils {
 


### PR DESCRIPTION
This allows the consumer of this library to use a different storage.
Additionally it allows proper dependency injection for tests instead
of directly testing within the UserDefaults.

Note: This is only for the settings stored in the Settings objects,
not for importer settings, which will be handled by #15

Fixes #68