### PR TITLE
Add shouldAllowUserToEdit property to ImportedTransaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is the importer of SwiftBeanCount. It reads files to create transactions. T
 2) Call `load()` on the importer.
 3) Check `possibleAccounts()` on the importer. If there is more than one or none, promt to user to enter/select the account to use. To show the user for which import they are entering information, you can display `importName`.
 4) Pass the result to the importer via `useAccount(name:)`.
-5) Call `nextTransaction()` to retrive transaction after transactions till it returns `nil`. It is recommended to allow the user the edit the transactions while doing this.
+5) Call `nextTransaction()` to retrive transaction after transactions till it returns `nil`. It is recommended to allow the user the edit the transactions while doing this, as long as `shouldAllowUserToEdit` is true.
 6) If the user edits the transaction, and you offer and they accept to save the new mapping, call `saveMapped(description:payee:accountName:)`.
 7) Get `balancesToImport()` and `pricesToImport()` from the importer.
 

--- a/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
+++ b/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
@@ -77,7 +77,8 @@ class CSVBaseImporter: BaseImporter {
             posting2 = Posting(accountName: categoryAccountName, amount: categoryAmount)
         }
         let transaction = Transaction(metaData: transactionMetaData, postings: [posting, posting2])
-        return ImportedTransaction(transaction: transaction, originalDescription: originalDescription, possibleDuplicate: getPossibleDuplicateFor(transaction))
+        let possibleDuplicate = getPossibleDuplicateFor(transaction)
+        return ImportedTransaction(transaction: transaction, originalDescription: originalDescription, possibleDuplicate: possibleDuplicate, shouldAllowUserToEdit: true)
     }
 
     func parseLine() -> CSVLine { // swiftlint:disable:this unavailable_function

--- a/Sources/SwiftBeanCountImporter/Importer.swift
+++ b/Sources/SwiftBeanCountImporter/Importer.swift
@@ -57,7 +57,13 @@ public struct ImportedTransaction {
 
     /// Transaction from the ledger of which the imported transaction
     /// might be a duplicate
-    let possibleDuplicate: Transaction?
+    public let possibleDuplicate: Transaction?
+
+    /// Indicates if the app should allow the user to edit the imported transaction.
+    ///
+    /// Some importer output transactions which normally do not require edits
+    /// e.g. from stock purchases. These indicate this by settings this value to true.
+    public let shouldAllowUserToEdit: Bool
 
     /// Saves a mapping of an imported transaction description to a different
     /// description, payee as well as account name

--- a/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
@@ -275,13 +275,13 @@ class ManuLifeImporter: BaseImporter, TransactionBalanceTextImporter {
             postings.insert(Posting(accountName: accountName, amount: Amount(number: -totalAmount, commoditySymbol: commoditySymbol, decimalDigits: 2)), at: 0)
         }
 
-        let prices: [Price] = buys.compactMap {  manuLifeBuy -> Price? in
-            let amount = ParserUtils.parseAmountFrom(string: manuLifeBuy.price, commoditySymbol: commoditySymbol)
-            return try? Price(date: date, commoditySymbol: manuLifeBuy.commodity, amount: amount)
+        let prices: [Price] = buys.compactMap { manuLifeBuy -> Price? in
+            try? Price(date: date, commoditySymbol: manuLifeBuy.commodity, amount: ParserUtils.parseAmountFrom(string: manuLifeBuy.price, commoditySymbol: commoditySymbol))
         }
 
         let transaction = Transaction(metaData: TransactionMetaData(date: date, payee: "", narration: "", flag: .complete, tags: []), postings: postings)
-        return (ImportedTransaction(transaction: transaction, originalDescription: "", possibleDuplicate: getPossibleDuplicateFor(transaction)), prices)
+        return (ImportedTransaction(transaction: transaction, originalDescription: "", possibleDuplicate: getPossibleDuplicateFor(transaction), shouldAllowUserToEdit: false),
+                prices)
     }
 
     /// Returns the first match of the capture group regex in the input string

--- a/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
@@ -74,6 +74,7 @@ final class CSVBaseImporterTests: XCTestCase {
 
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
+        XCTAssertTrue(importedTransaction!.shouldAllowUserToEdit)
 
         let noTransaction = importer.nextTransaction()
         XCTAssertNil(noTransaction)

--- a/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
@@ -65,7 +65,10 @@ final class ImporterTests: XCTestCase {
         let accountName = TestUtils.cash
         Settings.storage = TestStorage()
 
-        let importedTransaction = ImportedTransaction(transaction: TestUtils.transaction, originalDescription: originalDescription, possibleDuplicate: nil)
+        let importedTransaction = ImportedTransaction(transaction: TestUtils.transaction,
+                                                      originalDescription: originalDescription,
+                                                      possibleDuplicate: nil,
+                                                      shouldAllowUserToEdit: true)
         importedTransaction.saveMapped(description: description, payee: payee, accountName: accountName)
 
         XCTAssertEqual(Settings.allDescriptionMappings, [originalDescription: description])

--- a/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
@@ -165,6 +165,7 @@ final class ManuLifeImporterTests: XCTestCase {
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
+        XCTAssertFalse(transaction!.shouldAllowUserToEdit)
         XCTAssertNil(importer.nextTransaction())
         let prices = importer.pricesToImport()
         XCTAssertTrue(importer.balancesToImport().isEmpty)


### PR DESCRIPTION
Not all imported transactions need to be edited by the user afterwards,
so indicate to the consumer what can be skipped.