### PR TITLE
Remove importer settings and use metaData on account instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,9 @@ This is the importer of SwiftBeanCount. It reads files to create transactions. T
 
 ### Settings
 
-The different importers which are included in this library can be configured:
+There are settings for the date tolerance when detecting duplicate transactions, as well as for the mapping the user saved in step 6) of importing transactions. Your app can allow the user to view and edit these via the `Settings` object.
 
-1) Call `ImporterFactory.allImporters` to retreive all importers
-2) Call `importer.settingsName` to get the user friendly name of the importer
-3) Call `importer.settings` to get the `ImporterSetting`s which an importer offers
-3) Use `importer.get(setting: ImporterSetting)` and `importer.set(setting: ImporterSetting, to value: String)` to modify these settings.
-
-On top of this, there is a setting for the date tolerance when detecting duplicate transactions as well as the mapping the user saved in step 6) of importing transactions. Your app can allow the user to view and edit these via the `Settings` object.
+### More
 
 Please check out the complete documentation [here](https://nef10.github.io/SwiftBeanCountImporter/), or have a look at the [SwiftBeanCountImporterApp](https://github.com/Nef10/SwiftBeanCountImporterApp/) which uses this library.
 

--- a/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
+++ b/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
@@ -40,9 +40,7 @@ class CSVBaseImporter: BaseImporter {
     }
 
     override func nextTransaction() -> ImportedTransaction? {
-        guard let accountName = accountName else {
-            fatalError("No account configured")
-        }
+        guard let accountName = accountName else { fatalError("No account configured") }
         guard loaded, let data = lines.popLast() else {
             return nil
         }
@@ -66,9 +64,7 @@ class CSVBaseImporter: BaseImporter {
 
         let categoryAmount = Amount(number: -data.amount, commoditySymbol: commoditySymbol, decimalDigits: 2)
         let flag: Flag = description == originalDescription && payee == originalPayee ? .incomplete : .complete
-        let transactionMetaData = TransactionMetaData(date: data.date, payee: payee, narration: description, flag: flag, tags: [])
-        let amount = Amount(number: data.amount, commoditySymbol: commoditySymbol, decimalDigits: 2)
-        let posting = Posting(accountName: accountName, amount: amount)
+        let posting = Posting(accountName: accountName, amount: Amount(number: data.amount, commoditySymbol: commoditySymbol, decimalDigits: 2))
         var posting2: Posting
         if let price = data.price {
             let pricePer = Amount(number: categoryAmount.number / price.number, commoditySymbol: commoditySymbol, decimalDigits: 7)
@@ -76,9 +72,12 @@ class CSVBaseImporter: BaseImporter {
         } else {
             posting2 = Posting(accountName: categoryAccountName, amount: categoryAmount)
         }
-        let transaction = Transaction(metaData: transactionMetaData, postings: [posting, posting2])
-        let possibleDuplicate = getPossibleDuplicateFor(transaction)
-        return ImportedTransaction(transaction: transaction, originalDescription: originalDescription, possibleDuplicate: possibleDuplicate, shouldAllowUserToEdit: true)
+        let transaction = Transaction(metaData: TransactionMetaData(date: data.date, payee: payee, narration: description, flag: flag), postings: [posting, posting2])
+        return ImportedTransaction(transaction: transaction,
+                                   originalDescription: originalDescription,
+                                   possibleDuplicate: getPossibleDuplicateFor(transaction),
+                                   shouldAllowUserToEdit: true,
+                                   accountName: accountName)
     }
 
     func parseLine() -> CSVLine { // swiftlint:disable:this unavailable_function

--- a/Sources/SwiftBeanCountImporter/Importer.swift
+++ b/Sources/SwiftBeanCountImporter/Importer.swift
@@ -65,6 +65,12 @@ public struct ImportedTransaction {
     /// e.g. from stock purchases. These indicate this by settings this value to true.
     public let shouldAllowUserToEdit: Bool
 
+    /// AccountName of the account the import is for
+    ///
+    /// You can use this to detect which posting the user should not edit
+    /// Note: Not set on imported transactions which have shouldAllowUserToEdit set to false
+    public let accountName: AccountName?
+
     /// Saves a mapping of an imported transaction description to a different
     /// description, payee as well as account name
     ///
@@ -87,38 +93,14 @@ public struct ImportedTransaction {
 
 }
 
-/// Represents a single setting of an importer
-public struct ImporterSetting {
-
-    let identifier: String
-
-    /// User friendly name of the setting
-    public let name: String
-
-}
-
 /// Protocol to represent an Importer, regardless of type
 public protocol Importer {
-
-    /// User friendly name of the Importer
-    ///
-    /// Should be used in the settings to group the setting of this importer.
-    static var settingsName: String { get }
-
-    /// Settings of this importer
-    static var settings: [ImporterSetting] { get }
 
     /// A description of the import, e.g. a file name together with the importer name
     ///
     /// Can be used in the UI when an importer requests more information, e.g.
     /// account selection or credentials
     var importName: String { get }
-
-    /// AccountName of the account the import is for
-    ///
-    /// You can use this to detect which posting the user should not edit
-    /// Note: Some importers work on child accounts of the given one
-    var accountName: AccountName? { get }
 
     /// Get possible account names for this importer
     func possibleAccountNames() -> [AccountName]
@@ -139,6 +121,7 @@ public protocol Importer {
 
     /// Returns the next `ImportedTransaction`
     ///
+    /// You must call `load` before you call this function.
     /// Returns nil when there are no more lines left.
     func nextTransaction() -> ImportedTransaction?
 
@@ -153,31 +136,5 @@ public protocol Importer {
     /// Only some importer can import prices, so it might return an empty array
     /// Only call this function after you received all transactions
     func pricesToImport() -> [Price]
-
-}
-
-extension Importer {
-
-    /// Get the settings value of a specific setting
-    /// - Parameter setting: Setting to read
-    /// - Returns: value of the setting
-    public static func get(setting: ImporterSetting) -> String? {
-        UserDefaults.standard.string(forKey: getUserDefaultsKey(for: setting))
-    }
-
-    /// Set the value of a sepcific setting
-    /// - Parameters:
-    ///   - setting: Setting to write
-    ///   - value: value to set
-    public static func set(setting: ImporterSetting, to value: String) {
-        UserDefaults.standard.set(value, forKey: getUserDefaultsKey(for: setting))
-    }
-
-    /// Get the key used in the `UserDefaults` to save a particular setting
-    /// - Parameter setting: Setting of which you want to have the key
-    /// - Returns: key used in the `UserDefaults`
-    public static func getUserDefaultsKey(for setting: ImporterSetting) -> String {
-        "\(String(describing: self)).\(setting.identifier)"
-    }
 
 }

--- a/Sources/SwiftBeanCountImporter/Importers/LunchOnUsImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/LunchOnUsImporter.swift
@@ -16,7 +16,8 @@ class LunchOnUsImporter: CSVBaseImporter, CSVImporter {
     private static let description = "location"
 
     static let headers = [[date, type, amount, "invoice", "remaining", description]]
-    override class var settingsName: String { "LunchOnUs Card" }
+
+    override class var importerType: String { "lunch-on-us" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()

--- a/Sources/SwiftBeanCountImporter/Importers/N26Importer.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/N26Importer.swift
@@ -20,7 +20,8 @@ class N26Importer: CSVBaseImporter, CSVImporter {
     private static let recipient = "Empfänger"
 
     static let headers = [[date, recipient, "Kontonummer", "Transaktionstyp", description, "Kategorie", amount, amountForeignCurrency, foreignCurrency, exchangeRate]]
-    override class var settingsName: String { "N26" }
+
+    override class var importerType: String { "n26" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()

--- a/Sources/SwiftBeanCountImporter/Importers/RBCImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/RBCImporter.swift
@@ -16,7 +16,8 @@ class RBCImporter: CSVBaseImporter, CSVImporter {
     private static let amount = "CAD$"
 
     static let headers = [["Account Type", "Account Number", date, "Cheque Number", description1, description2, amount, "USD$"]]
-    override static var settingsName: String { "RBC Accounts + CC" }
+
+    override class var importerType: String { "rbc" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()

--- a/Sources/SwiftBeanCountImporter/Importers/RogersImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/RogersImporter.swift
@@ -25,7 +25,8 @@ class RogersImporter: CSVBaseImporter, CSVImporter {
         [date2, "Activity Type", description, "Merchant Category", amount, "Rewards"],
         [date2, "Activity Type", description, "Merchant Category Description", amount, "Rewards"],
     ]
-    override class var settingsName: String { "Rogers CC" }
+
+    override class var importerType: String { "rogers" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()

--- a/Sources/SwiftBeanCountImporter/Importers/SimpliiImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/SimpliiImporter.swift
@@ -16,7 +16,8 @@ class SimpliiImporter: CSVBaseImporter, CSVImporter {
     private static let amountOut = "Funds Out"
 
     static let headers = [[date, description, amountOut, amountIn]]
-    override class var settingsName: String { "Simplii Accounts" }
+
+    override class var importerType: String { "simplii" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()

--- a/Sources/SwiftBeanCountImporter/Importers/TangerineAccountImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/TangerineAccountImporter.swift
@@ -17,10 +17,10 @@ class TangerineAccountImporter: CSVBaseImporter, CSVImporter {
     private static let amount = "Amount"
 
     static let headers = [[date, "Transaction", name, memo, amount]]
-    override class var settingsName: String { "Tangerine Accounts" }
-
     static let interac = "INTERAC e-Transfer From: "
     static let interest = "Interest Paid"
+
+    override class var importerType: String { "tangerine-account" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()
@@ -32,11 +32,8 @@ class TangerineAccountImporter: CSVBaseImporter, CSVImporter {
         "Tangerine Account File \(fileName)"
     }
 
-    override func possibleAccountNames() -> [AccountName] {
-        if let accountName = accountName {
-            return [accountName]
-        }
-        let possibleAccountNames = accountsFromSettings()
+    override func accountsFromLedger() -> [AccountName] {
+        let possibleAccountNames = super.accountsFromLedger()
         let possibleAccounts = possibleAccountNames.compactMap { accountName in ledger?.accounts.first { $0.name == accountName } }
         for account in possibleAccounts {
             if let number = account.metaData["number"], fileName.contains(number) {

--- a/Sources/SwiftBeanCountImporter/Importers/TangerineCardImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/TangerineCardImporter.swift
@@ -15,7 +15,8 @@ class TangerineCardImporter: CSVBaseImporter, CSVImporter {
     private static let amount = "Amount"
 
     static let headers = [[date, "Transaction", name, "Memo", amount]]
-    override class var settingsName: String { "Tangerine CC" }
+
+    override class var importerType: String { "tangerine-card" }
 
     private static var dateFormatter: DateFormatter = {
         var dateFormatter = DateFormatter()

--- a/Sources/SwiftBeanCountImporter/Settings.swift
+++ b/Sources/SwiftBeanCountImporter/Settings.swift
@@ -25,19 +25,22 @@ public protocol SettingsStorage {
 public enum Settings {
 
     /// Storage key for the payee mapping
-    static let payeesKey = "payees"
+    private static let payeesKey = "payees"
     /// Storage key for the account mapping
-    static let accountsKey = "accounts"
+    private static let accountsKey = "accounts"
     /// Storage key for the description mapping
-    static let descriptionKey = "description"
+    private static let descriptionKey = "description"
     /// Storage key for the date tolerance to detect duplicate transactions
-    static let dateToleranceKey = "date_tolerance"
+    private static let dateToleranceKey = "date_tolerance"
 
     /// Default date tolerance to detect duplicate transactions
     static let defaultDateTolerance = 2 // days
-
+    // Default account name to book the other posting of an imported transaction to
     static let defaultAccountName = "Expenses:TODO"
+    /// Currency to use if the account does not have a currency specified
     static let fallbackCommodity = "CAD"
+    /// Key used to save the importer type into the metaData of an account
+    static let importerTypeKey = "importer-type"
 
     /// A Storage which saves the settings
     ///

--- a/Tests/SwiftBeanCountImporterTests/BaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/BaseImporterTests.swift
@@ -18,8 +18,8 @@ final class BaseImporterTests: XCTestCase {
         XCTAssertEqual(importer.ledger, TestUtils.ledger)
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(BaseImporter.settingsName, "")
+    func testImporterType() {
+        XCTAssertEqual(BaseImporter.importerType, "")
     }
 
     func testLoad() {
@@ -47,13 +47,6 @@ final class BaseImporterTests: XCTestCase {
         XCTAssertTrue(importer.pricesToImport().isEmpty)
     }
 
-    func testSettings() {
-        let settings = BaseImporter.settings
-        XCTAssertEqual(settings.count, 1)
-        XCTAssertEqual(settings[0].identifier, BaseImporter.accountsSetting.identifier)
-        XCTAssertEqual(settings[0].name, BaseImporter.accountsSetting.name)
-    }
-
     func testCommoditySymbol() {
         var importer = BaseImporter(ledger: TestUtils.ledger)
         XCTAssertEqual(importer.commoditySymbol, Settings.fallbackCommodity)
@@ -72,19 +65,21 @@ final class BaseImporterTests: XCTestCase {
     }
 
     func testPossibleAccountNames() {
-        let importer = BaseImporter(ledger: TestUtils.ledger)
-        let key = BaseImporter.getUserDefaultsKey(for: BaseImporter.accountsSetting)
-
-        UserDefaults.standard.removeObject(forKey: key)
+        let ledger = TestUtils.ledger
+        var importer = BaseImporter(ledger: ledger)
         var possibleAccountNames = importer.possibleAccountNames()
         XCTAssertEqual(possibleAccountNames.count, 0)
 
-        UserDefaults.standard.set(TestUtils.cash.fullName, forKey: key)
+        var account = Account(name: TestUtils.cash, commoditySymbol: TestUtils.usd, metaData: [Settings.importerTypeKey: ""])
+        try! ledger.add(account)
+        importer = BaseImporter(ledger: ledger)
         possibleAccountNames = importer.possibleAccountNames()
         XCTAssertEqual(possibleAccountNames.count, 1)
         XCTAssertEqual(possibleAccountNames[0], TestUtils.cash)
 
-        UserDefaults.standard.set("\(TestUtils.cash.fullName), \(TestUtils.chequing.fullName)", forKey: key)
+        account = Account(name: TestUtils.chequing, commoditySymbol: TestUtils.usd, metaData: [Settings.importerTypeKey: ""])
+        try! ledger.add(account)
+        importer = BaseImporter(ledger: ledger)
         possibleAccountNames = importer.possibleAccountNames()
         XCTAssertEqual(possibleAccountNames.count, 2)
         XCTAssertTrue(possibleAccountNames.contains(TestUtils.cash))
@@ -95,8 +90,6 @@ final class BaseImporterTests: XCTestCase {
         possibleAccountNames = importer.possibleAccountNames()
         XCTAssertEqual(possibleAccountNames.count, 1)
         XCTAssertEqual(possibleAccountNames[0], TestUtils.cash)
-
-        UserDefaults.standard.removeObject(forKey: key)
     }
 
     func testSavedPayee() {
@@ -133,7 +126,7 @@ final class BaseImporterTests: XCTestCase {
     func testGetPossibleDuplicateFor() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.lederAccounts
         let transaction = TestUtils.transaction
         ledger.add(transaction)
 
@@ -144,7 +137,7 @@ final class BaseImporterTests: XCTestCase {
     func testGetPossibleDuplicateForDateToleranceInside() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.lederAccounts
         let transaction = TestUtils.transaction
         ledger.add(transaction)
 
@@ -172,7 +165,7 @@ final class BaseImporterTests: XCTestCase {
     func testGetPossibleDuplicateForDateToleranceOutside() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.lederAccounts
         let transaction = TestUtils.transaction
         ledger.add(transaction)
 

--- a/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
@@ -75,6 +75,7 @@ final class CSVBaseImporterTests: XCTestCase {
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertTrue(importedTransaction!.shouldAllowUserToEdit)
+        XCTAssertEqual(importedTransaction!.accountName, TestUtils.cash)
 
         let noTransaction = importer.nextTransaction()
         XCTAssertNil(noTransaction)
@@ -134,7 +135,7 @@ final class CSVBaseImporterTests: XCTestCase {
     func testGetPossibleDuplicateFor() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.lederAccounts
         let transaction = TestUtils.transaction
         ledger.add(transaction)
 
@@ -149,7 +150,7 @@ final class CSVBaseImporterTests: XCTestCase {
     func testGetPossibleDuplicateForNone() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.lederAccounts
         let transaction = TestUtils.transaction
         ledger.add(transaction)
 

--- a/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/ImporterTests.swift
@@ -10,11 +10,6 @@ import Foundation
 import SwiftBeanCountModel
 import XCTest
 
-private class TestImporter: BaseImporter {
-    static let setting = ImporterSetting(identifier: "accounts", name: "Account(s)")
-    override class var settings: [ImporterSetting] { [] }
-}
-
 final class ImporterTests: XCTestCase {
 
     func testAllImporters() {
@@ -50,14 +45,6 @@ final class ImporterTests: XCTestCase {
         XCTAssertTrue(result is ManuLifeImporter)
     }
 
-    func testSettings() {
-        let value = "GFDSGFD"
-        TestImporter.set(setting: TestImporter.setting, to: value)
-        XCTAssertEqual(TestImporter.get(setting: TestImporter.setting), value)
-        let key = TestImporter.getUserDefaultsKey(for: TestImporter.setting)
-        XCTAssertEqual(UserDefaults.standard.string(forKey: key), value)
-    }
-
     func testImportedTransactionSaveMapped() {
         let originalDescription = "abcd"
         let description = "ab"
@@ -68,7 +55,8 @@ final class ImporterTests: XCTestCase {
         let importedTransaction = ImportedTransaction(transaction: TestUtils.transaction,
                                                       originalDescription: originalDescription,
                                                       possibleDuplicate: nil,
-                                                      shouldAllowUserToEdit: true)
+                                                      shouldAllowUserToEdit: true,
+                                                      accountName: nil)
         importedTransaction.saveMapped(description: description, payee: payee, accountName: accountName)
 
         XCTAssertEqual(Settings.allDescriptionMappings, [originalDescription: description])

--- a/Tests/SwiftBeanCountImporterTests/Importers/LunchOnUsImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/LunchOnUsImporterTests.swift
@@ -16,8 +16,8 @@ final class LunchOnUsImporterTests: XCTestCase {
         XCTAssertEqual(LunchOnUsImporter.headers, [["date", "type", "amount", "invoice", "remaining", "location"]])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(LunchOnUsImporter.settingsName, "LunchOnUs Card")
+    func testImporterType() {
+        XCTAssertEqual(LunchOnUsImporter.importerType, "lunch-on-us")
     }
 
     func testImportName() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
@@ -119,12 +119,8 @@ private var balancePricesResult: String = { """
 
 final class ManuLifeImporterTests: XCTestCase {
 
-    func testSettingsName() {
-        XCTAssertEqual(ManuLifeImporter.settingsName, "ManuLife")
-    }
-
-    func testSettings() {
-        XCTAssertEqual(ManuLifeImporter.settings.count, 6)
+    func testImporterType() {
+        XCTAssertEqual(ManuLifeImporter.importerType, "manulife")
     }
 
     func testImportName() {
@@ -141,7 +137,7 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testParseBalance() {
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: "", balance: balance)
+        let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: "", balance: balance)
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         XCTAssertNil(importer.nextTransaction())
@@ -157,15 +153,14 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testTransaction() {
-        clearSettings()
-
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transaction, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
         XCTAssertFalse(transaction!.shouldAllowUserToEdit)
+        XCTAssertNil(transaction!.accountName)
         XCTAssertNil(importer.nextTransaction())
         let prices = importer.pricesToImport()
         XCTAssertTrue(importer.balancesToImport().isEmpty)
@@ -178,8 +173,7 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testBalanceAndTransaction() {
-        clearSettings()
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: balance)
+        let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transaction, balance: balance)
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         let transaction = importer.nextTransaction()
@@ -197,13 +191,8 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testTransactionSettings() {
-        ManuLifeImporter.set(setting: ManuLifeImporter.employeeBasicSetting, to: "2.5")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employerBasicSetting, to: "3.25")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employerMatchSetting, to: "2.5")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employeeVoluntarySetting, to: "1.75")
-        ManuLifeImporter.set(setting: ManuLifeImporter.cashAccountSetting, to: "Setting")
-
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "3.25", employerMatch: "2.5", employeeVoluntary: "1.75", cashSuffix: "Setting")
+        let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         let transaction = importer.nextTransaction()
@@ -227,18 +216,11 @@ final class ManuLifeImporterTests: XCTestCase {
             2020-06-05 price 1234 ML Category Fund 9876 y8 21.221 USD
             2020-06-05 price \(TestUtils.fundSymbol) 9.148 USD
             """)
-
-        clearSettings()
     }
 
     func testTransactionSettingsZero1() {
-        ManuLifeImporter.set(setting: ManuLifeImporter.employeeBasicSetting, to: "2.5")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employerBasicSetting, to: "5")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employerMatchSetting, to: "2.5")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employeeVoluntarySetting, to: "0")
-        ManuLifeImporter.set(setting: ManuLifeImporter.cashAccountSetting, to: "Setting")
-
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "5", employerMatch: "2.5", employeeVoluntary: "0", cashSuffix: "Setting")
+        let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         let transaction = importer.nextTransaction()
@@ -261,18 +243,11 @@ final class ManuLifeImporterTests: XCTestCase {
             2020-06-05 price 1234 ML Category Fund 9876 y8 21.221 USD
             2020-06-05 price \(TestUtils.fundSymbol) 9.148 USD
             """)
-
-        clearSettings()
     }
 
     func testTransactionSettingsZero2() {
-        ManuLifeImporter.set(setting: ManuLifeImporter.employeeBasicSetting, to: "0")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employerBasicSetting, to: "0")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employerMatchSetting, to: "0")
-        ManuLifeImporter.set(setting: ManuLifeImporter.employeeVoluntarySetting, to: "1")
-        ManuLifeImporter.set(setting: ManuLifeImporter.cashAccountSetting, to: "Setting")
-
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        let ledger = TestUtils.ledgerManuLife(employeeBasic: "0", employerBasic: "0", employerMatch: "0", employeeVoluntary: "1", cashSuffix: "Setting")
+        let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         let transaction = importer.nextTransaction()
@@ -290,12 +265,10 @@ final class ManuLifeImporterTests: XCTestCase {
             2020-06-05 price 1234 ML Category Fund 9876 y8 21.221 USD
             2020-06-05 price \(TestUtils.fundSymbol) 9.148 USD
             """)
-
-        clearSettings()
     }
 
     func testTransactionGarbage() {
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: "This is not a valid Transaction", balance: "")
+        let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: "This is not a valid Transaction", balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         XCTAssertNil(importer.nextTransaction())
@@ -304,7 +277,7 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testTransactionInvalidData() {
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transactionInvalidDate, balance: "")
+        let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transactionInvalidDate, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         XCTAssertNil(importer.nextTransaction())
@@ -315,7 +288,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testGetPossibleDuplicateFor() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.ledgerManuLife()
         let metaData = TransactionMetaData(date: TestUtils.date20200605, payee: "a", narration: "b", flag: .incomplete, tags: [])
         let posting1 = Posting(accountName: try! AccountName("Assets:Cash:Parking"),
                                amount: Amount(number: Decimal(-149.28), commoditySymbol: TestUtils.usd, decimalDigits: 2),
@@ -326,7 +299,7 @@ final class ManuLifeImporterTests: XCTestCase {
         let transaction1 = Transaction(metaData: metaData, postings: [posting1, posting2])
         ledger.add(transaction1)
 
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.cash)
         let importedTransaction = importer.nextTransaction()
@@ -337,24 +310,15 @@ final class ManuLifeImporterTests: XCTestCase {
     func testGetPossibleDuplicateForNone() {
         Settings.storage = TestStorage()
         Settings.dateToleranceInDays = 2
-        let ledger = TestUtils.lederFund
+        let ledger = TestUtils.ledgerManuLife()
         let transaction1 = TestUtils.transaction
         ledger.add(transaction1)
 
-        let importer = ManuLifeImporter(ledger: TestUtils.lederFund, transaction: transaction, balance: "")
+        let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
         importer.useAccount(name: TestUtils.chequing)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertNil(importedTransaction!.possibleDuplicate)
     }
-
-    private func clearSettings() {
-        UserDefaults.standard.removeObject(forKey: ManuLifeImporter.getUserDefaultsKey(for: ManuLifeImporter.employeeBasicSetting))
-        UserDefaults.standard.removeObject(forKey: ManuLifeImporter.getUserDefaultsKey(for: ManuLifeImporter.employerBasicSetting))
-        UserDefaults.standard.removeObject(forKey: ManuLifeImporter.getUserDefaultsKey(for: ManuLifeImporter.employerMatchSetting))
-        UserDefaults.standard.removeObject(forKey: ManuLifeImporter.getUserDefaultsKey(for: ManuLifeImporter.employeeVoluntarySetting))
-        UserDefaults.standard.removeObject(forKey: ManuLifeImporter.getUserDefaultsKey(for: ManuLifeImporter.cashAccountSetting))
-    }
-
 }

--- a/Tests/SwiftBeanCountImporterTests/Importers/N26ImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/N26ImporterTests.swift
@@ -29,8 +29,8 @@ final class N26ImporterTests: XCTestCase {
         ])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(N26Importer.settingsName, "N26")
+    func testImporterType() {
+        XCTAssertEqual(N26Importer.importerType, "n26")
     }
 
     func testImportName() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/RBCImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/RBCImporterTests.swift
@@ -17,8 +17,8 @@ final class RBCImporterTests: XCTestCase {
                        [["Account Type", "Account Number", "Transaction Date", "Cheque Number", "Description 1", "Description 2", "CAD$", "USD$"]])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(RBCImporter.settingsName, "RBC Accounts + CC")
+    func testImporterType() {
+        XCTAssertEqual(RBCImporter.importerType, "rbc")
     }
 
     func testImportName() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/RogersImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/RogersImporterTests.swift
@@ -25,8 +25,8 @@ final class RogersImporterTests: XCTestCase {
         ])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(RogersImporter.settingsName, "Rogers CC")
+    func testImporterType() {
+        XCTAssertEqual(RogersImporter.importerType, "rogers")
     }
 
     func testImportName() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/SimpliiImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/SimpliiImporterTests.swift
@@ -16,8 +16,8 @@ final class SimpliiImporterTests: XCTestCase {
         XCTAssertEqual(SimpliiImporter.headers, [["Date", "Transaction Details", "Funds Out", "Funds In"]])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(SimpliiImporter.settingsName, "Simplii Accounts")
+    func testImporterType() {
+        XCTAssertEqual(SimpliiImporter.importerType, "simplii")
     }
 
     func testImportName() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/TangerineAccountImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/TangerineAccountImporterTests.swift
@@ -17,8 +17,8 @@ final class TangerineAccountImporterTests: XCTestCase {
                        [["Date", "Transaction", "Name", "Memo", "Amount"]])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(TangerineAccountImporter.settingsName, "Tangerine Accounts")
+    func testImporterType() {
+        XCTAssertEqual(TangerineAccountImporter.importerType, "tangerine-account")
     }
 
     func testImportName() {
@@ -26,9 +26,6 @@ final class TangerineAccountImporterTests: XCTestCase {
     }
 
     func testPossibleAccountNames() {
-        let key = TangerineAccountImporter.getUserDefaultsKey(for: TangerineAccountImporter.accountsSetting)
-        UserDefaults.standard.set("\(TestUtils.cash.fullName), \(TestUtils.chequing.fullName)", forKey: key)
-
         var importer = TangerineAccountImporter(ledger: TestUtils.lederAccountNumers,
                                                 csvReader: TestUtils.basicCSVReader,
                                                 fileName: "Export \(TestUtils.accountNumberChequing).csv")
@@ -51,8 +48,6 @@ final class TangerineAccountImporterTests: XCTestCase {
         possibleAccountNames = importer.possibleAccountNames()
         XCTAssertEqual(possibleAccountNames.count, 1)
         XCTAssertEqual(possibleAccountNames[0], TestUtils.cash)
-
-        UserDefaults.standard.removeObject(forKey: key)
     }
 
     func testParseLine() {

--- a/Tests/SwiftBeanCountImporterTests/Importers/TangerineCardImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/TangerineCardImporterTests.swift
@@ -17,8 +17,8 @@ final class TangerineCardImporterTests: XCTestCase {
                        [["Transaction date", "Transaction", "Name", "Memo", "Amount"]])
     }
 
-    func testSettingsName() {
-        XCTAssertEqual(TangerineCardImporter.settingsName, "Tangerine CC")
+    func testImporterType() {
+        XCTAssertEqual(TangerineCardImporter.importerType, "tangerine-card")
     }
 
     func testImportName() {

--- a/Tests/SwiftBeanCountImporterTests/TestUtils.swift
+++ b/Tests/SwiftBeanCountImporterTests/TestUtils.swift
@@ -74,16 +74,19 @@ enum TestUtils {
     static var lederAccountNumers: Ledger = {
         let ledger = Ledger()
         try! ledger.add(TestUtils.usdCommodity)
-        let account1 = Account(name: TestUtils.chequing, commoditySymbol: TestUtils.usd, metaData: ["number": "\(accountNumberChequing)"] )
-        let account2 = Account(name: TestUtils.cash, commoditySymbol: TestUtils.usd, metaData: ["number": "\(accountNumberCash)"] )
+        let account1 = Account(name: TestUtils.chequing,
+                               commoditySymbol: TestUtils.usd,
+                               metaData: ["number": "\(accountNumberChequing)", Settings.importerTypeKey: TangerineAccountImporter.importerType] )
+        let account2 = Account(name: TestUtils.cash,
+                               commoditySymbol: TestUtils.usd,
+                               metaData: ["number": "\(accountNumberCash)", Settings.importerTypeKey: TangerineAccountImporter.importerType] )
         try! ledger.add(account1)
         try! ledger.add(account2)
         return ledger
     }()
 
-    static var lederFund: Ledger = {
+    static var lederAccounts: Ledger = {
         let ledger = Ledger()
-        try! ledger.add(Commodity(symbol: fundSymbol, metaData: ["name": fundName]))
         let account1 = Account(name: TestUtils.chequing, commoditySymbol: TestUtils.usd)
         let account2 = Account(name: TestUtils.cash, commoditySymbol: TestUtils.usd)
         try! ledger.add(account1)
@@ -132,6 +135,36 @@ enum TestUtils {
         try! CSVReader(stream: InputStream(data: content.data(using: .utf8)!),
                        hasHeaderRow: true,
                        trimFields: true)
+    }
+
+    static func ledgerManuLife(
+        employeeBasic: String? = nil,
+        employerBasic: String? = nil,
+        employerMatch: String? = nil,
+        employeeVoluntary: String? = nil,
+        cashSuffix: String? = nil
+    ) -> Ledger {
+        let ledger = Ledger()
+        try! ledger.add(Commodity(symbol: fundSymbol, metaData: ["name": fundName]))
+        var metaData = [String: String]()
+        if let employeeBasic = employeeBasic {
+            metaData["employee-basic-fraction"] = employeeBasic
+        }
+        if let employerBasic = employerBasic {
+            metaData["employer-basic-fraction"] = employerBasic
+        }
+        if let employerMatch = employerMatch {
+            metaData["employer-match-fraction"] = employerMatch
+        }
+        if let employeeVoluntary = employeeVoluntary {
+            metaData["employee-voluntary-fraction"] = employeeVoluntary
+        }
+        if let cashSuffix = cashSuffix {
+            metaData["cash-account-suffix"] = cashSuffix
+        }
+        let account = Account(name: TestUtils.cash, commoditySymbol: TestUtils.usd, metaData: metaData)
+        try! ledger.add(account)
+        return ledger
     }
 
 }


### PR DESCRIPTION
The individual importers no longer have settings. Instead these are
now read from the beancount file.
Importers now also no longer expose accoutName, instead the imported
transaction has an account name, to keep identifying which posting
not to edit.

Note: Breaking change

Fixes #15
Fixes #20