### PR TITLE
ManuLife importer: Add meta data on parking/cash account

### DIFF
--- a/Sources/SwiftBeanCountImporter/BaseImporter.swift
+++ b/Sources/SwiftBeanCountImporter/BaseImporter.swift
@@ -27,8 +27,14 @@ class BaseImporter: Importer {
 
     class var importerType: String { "" } // Override
 
-    private(set) var accountName: AccountName?
     var ledger: Ledger?
+    private(set) var accountName: AccountName?
+    var configuredAccountName: AccountName {
+        guard let accountName = accountName else {
+            fatalError("No account configured - You must call useAccount(name:) before attempting to import")
+        }
+        return accountName
+    }
     var importName: String { "" } // Override
 
     var commoditySymbol: String {

--- a/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
+++ b/Sources/SwiftBeanCountImporter/CSVBaseImporter.swift
@@ -40,7 +40,6 @@ class CSVBaseImporter: BaseImporter {
     }
 
     override func nextTransaction() -> ImportedTransaction? {
-        guard let accountName = accountName else { fatalError("No account configured") }
         guard loaded, let data = lines.popLast() else {
             return nil
         }
@@ -64,7 +63,7 @@ class CSVBaseImporter: BaseImporter {
 
         let categoryAmount = Amount(number: -data.amount, commoditySymbol: commoditySymbol, decimalDigits: 2)
         let flag: Flag = description == originalDescription && payee == originalPayee ? .incomplete : .complete
-        let posting = Posting(accountName: accountName, amount: Amount(number: data.amount, commoditySymbol: commoditySymbol, decimalDigits: 2))
+        let posting = Posting(accountName: configuredAccountName, amount: Amount(number: data.amount, commoditySymbol: commoditySymbol, decimalDigits: 2))
         var posting2: Posting
         if let price = data.price {
             let pricePer = Amount(number: categoryAmount.number / price.number, commoditySymbol: commoditySymbol, decimalDigits: 7)
@@ -77,7 +76,7 @@ class CSVBaseImporter: BaseImporter {
                                    originalDescription: originalDescription,
                                    possibleDuplicate: getPossibleDuplicateFor(transaction),
                                    shouldAllowUserToEdit: true,
-                                   accountName: accountName)
+                                   accountName: configuredAccountName)
     }
 
     func parseLine() -> CSVLine { // swiftlint:disable:this unavailable_function

--- a/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
@@ -44,29 +44,12 @@ class ManuLifeImporter: BaseImporter, TransactionBalanceTextImporter {
     private let transactionInputString: String
     private let balanceInputString: String
 
-    private var employeeBasicFraction: Double { Double(ledger?.accounts.first { $0.name == accountName }?.metaData["employee-basic-fraction"] ?? "") ?? defaultContribution }
-    private var employerBasicFraction: Double { Double(ledger?.accounts.first { $0.name == accountName }?.metaData["employer-basic-fraction"] ?? "") ?? defaultContribution }
-    private var employerMatchFraction: Double { Double(ledger?.accounts.first { $0.name == accountName }?.metaData["employer-match-fraction"] ?? "") ?? defaultContribution }
-    private var employeeVoluntaryFraction: Double {
-        Double(ledger?.accounts.first { $0.name == accountName }?.metaData["employee-voluntary-fraction"] ?? "") ?? defaultContribution
-    }
-
-    private var accountString: String {
-        guard let accountName = accountName else {
-            fatalError("No account configured")
-        }
-        return accountName.fullName.split(separator: ":").dropLast(1).joined(separator: ":")
-    }
-
-    private var cashAccountName: String {
-        guard let accountName = accountName else {
-            fatalError("No account configured")
-        }
-        guard let cashAccountName = accountName.fullName.split(separator: ":").last else {
-            fatalError("Configured account is invalid")
-        }
-        return String(cashAccountName)
-    }
+    private var accountString: String { configuredAccountName.fullName.split(separator: ":").dropLast(1).joined(separator: ":") }
+    private var account: Account? { ledger?.accounts.first { $0.name == accountName } }
+    private var employeeBasicFraction: Double { Double(account?.metaData["employee-basic-fraction"] ?? "") ?? defaultContribution }
+    private var employerBasicFraction: Double { Double(account?.metaData["employer-basic-fraction"] ?? "") ?? defaultContribution }
+    private var employerMatchFraction: Double { Double(account?.metaData["employer-match-fraction"] ?? "") ?? defaultContribution }
+    private var employeeVoluntaryFraction: Double { Double(account?.metaData["employee-voluntary-fraction"] ?? "") ?? defaultContribution }
 
     // Results from parsing
     private var parsedManuLifeBalances = [ManuLifeBalance]()
@@ -275,9 +258,7 @@ class ManuLifeImporter: BaseImporter, TransactionBalanceTextImporter {
             }
         }
 
-        if let accountName = try? AccountName("\(accountString):\(cashAccountName)") {
-            postings.insert(Posting(accountName: accountName, amount: Amount(number: -totalAmount, commoditySymbol: commoditySymbol, decimalDigits: 2)), at: 0)
-        }
+        postings.insert(Posting(accountName: configuredAccountName, amount: Amount(number: -totalAmount, commoditySymbol: commoditySymbol, decimalDigits: 2)), at: 0)
 
         let prices: [Price] = buys.compactMap { manuLifeBuy -> Price? in
             try? Price(date: date, commoditySymbol: manuLifeBuy.commodity, amount: ParserUtils.parseAmountFrom(string: manuLifeBuy.price, commoditySymbol: commoditySymbol))

--- a/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
@@ -130,7 +130,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testParseEmpty() {
         let importer = ManuLifeImporter(ledger: nil, transaction: "", balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         XCTAssertNil(importer.nextTransaction())
         XCTAssertEqual(importer.balancesToImport(), [])
         XCTAssertEqual(importer.pricesToImport(), [])
@@ -139,7 +139,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testParseBalance() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: "", balance: balance)
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         XCTAssertNil(importer.nextTransaction())
         let balances = importer.balancesToImport()
         let prices = importer.pricesToImport()
@@ -155,7 +155,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testTransaction() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transaction, balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
@@ -175,7 +175,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testBalanceAndTransaction() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transaction, balance: balance)
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
@@ -191,10 +191,10 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testTransactionSettings() {
-        let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "3.25", employerMatch: "2.5", employeeVoluntary: "1.75", cashSuffix: "Setting")
+        let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "3.25", employerMatch: "2.5", employeeVoluntary: "1.75")
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
@@ -203,7 +203,7 @@ final class ManuLifeImporterTests: XCTestCase {
         let prices = importer.pricesToImport()
         XCTAssertEqual("\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))", """
             2020-06-05 * "" ""
-              Assets:Cash:Setting -149.28 USD
+              Assets:Cash:Parking -149.28 USD
               Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
               Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8 0.14336 1234 ML Category Fund 9876 y8 {21.221 USD}
               Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
@@ -219,10 +219,10 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testTransactionSettingsZero1() {
-        let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "5", employerMatch: "2.5", employeeVoluntary: "0", cashSuffix: "Setting")
+        let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "5", employerMatch: "2.5", employeeVoluntary: "0")
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
@@ -232,7 +232,7 @@ final class ManuLifeImporterTests: XCTestCase {
         XCTAssertEqual(prices.count, 2)
         XCTAssertEqual("\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))", """
             2020-06-05 * "" ""
-              Assets:Cash:Setting -149.28 USD
+              Assets:Cash:Parking -149.28 USD
               Assets:Cash:Employee:Basic:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
               Assets:Cash:Employer:Basic:1234 ML Category Fund 9876 y8 0.22056 1234 ML Category Fund 9876 y8 {21.221 USD}
               Assets:Cash:Employer:Match:1234 ML Category Fund 9876 y8 0.11028 1234 ML Category Fund 9876 y8 {21.221 USD}
@@ -246,10 +246,10 @@ final class ManuLifeImporterTests: XCTestCase {
     }
 
     func testTransactionSettingsZero2() {
-        let ledger = TestUtils.ledgerManuLife(employeeBasic: "0", employerBasic: "0", employerMatch: "0", employeeVoluntary: "1", cashSuffix: "Setting")
+        let ledger = TestUtils.ledgerManuLife(employeeBasic: "0", employerBasic: "0", employerMatch: "0", employeeVoluntary: "1")
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
@@ -258,7 +258,7 @@ final class ManuLifeImporterTests: XCTestCase {
         let prices = importer.pricesToImport()
         XCTAssertEqual("\(transaction!.transaction)\n\n\(prices.map { "\($0)" }.joined(separator: "\n"))", """
             2020-06-05 * "" ""
-              Assets:Cash:Setting -149.28 USD
+              Assets:Cash:Parking -149.28 USD
               Assets:Cash:Employee:Voluntary:1234 ML Category Fund 9876 y8 0.44112 1234 ML Category Fund 9876 y8 {21.221 USD}
               Assets:Cash:Employee:Voluntary:\(TestUtils.fundSymbol) 15.29544 \(TestUtils.fundSymbol) {9.148 USD}
 
@@ -270,7 +270,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testTransactionGarbage() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: "This is not a valid Transaction", balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         XCTAssertNil(importer.nextTransaction())
         XCTAssertEqual(importer.balancesToImport(), [])
         XCTAssertEqual(importer.pricesToImport(), [])
@@ -279,7 +279,7 @@ final class ManuLifeImporterTests: XCTestCase {
     func testTransactionInvalidData() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transactionInvalidDate, balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         XCTAssertNil(importer.nextTransaction())
         XCTAssertEqual(importer.balancesToImport(), [])
         XCTAssertEqual(importer.pricesToImport(), [])
@@ -301,7 +301,7 @@ final class ManuLifeImporterTests: XCTestCase {
 
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
+        importer.useAccount(name: TestUtils.parking)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertEqual(importedTransaction!.possibleDuplicate, transaction1)

--- a/Tests/SwiftBeanCountImporterTests/TestUtils.swift
+++ b/Tests/SwiftBeanCountImporterTests/TestUtils.swift
@@ -109,6 +109,10 @@ enum TestUtils {
         try! AccountName("Assets:Cash")
     }()
 
+    static var parking: AccountName = {
+        try! AccountName("Assets:Cash:Parking")
+    }()
+
     static var chequing: AccountName = {
         try! AccountName("Assets:Chequing")
     }()
@@ -141,8 +145,7 @@ enum TestUtils {
         employeeBasic: String? = nil,
         employerBasic: String? = nil,
         employerMatch: String? = nil,
-        employeeVoluntary: String? = nil,
-        cashSuffix: String? = nil
+        employeeVoluntary: String? = nil
     ) -> Ledger {
         let ledger = Ledger()
         try! ledger.add(Commodity(symbol: fundSymbol, metaData: ["name": fundName]))
@@ -159,10 +162,7 @@ enum TestUtils {
         if let employeeVoluntary = employeeVoluntary {
             metaData["employee-voluntary-fraction"] = employeeVoluntary
         }
-        if let cashSuffix = cashSuffix {
-            metaData["cash-account-suffix"] = cashSuffix
-        }
-        let account = Account(name: TestUtils.cash, commoditySymbol: TestUtils.usd, metaData: metaData)
+        let account = Account(name: TestUtils.parking, commoditySymbol: TestUtils.usd, metaData: metaData)
         try! ledger.add(account)
         return ledger
     }


### PR DESCRIPTION
So one does not need to have an unused non-leaf account just for the
meta data in the beancount file