### PR TITLE
Use delegate to get account name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,11 @@ This is the importer of SwiftBeanCount. It reads files to create transactions. T
 ### Import Transactions
 
 1) Create an `Importer` via either `ImporterFactory.new(ledger: Ledger?, url: URL?)` or `ImporterFactory.new(ledger: Ledger?, transaction: String, balance: String)`, depending on what you want to import.
-2) Call `load()` on the importer.
-3) Check `possibleAccountNames()` on the importer. If there is more than one or none, promt to user to enter/select the account to use. To show the user for which import they are entering information, you can display `importName`.
-4) Pass the result to the importer via `useAccount(name:)`.
-5) Call `nextTransaction()` to retrive transaction after transactions till it returns `nil`. It is recommended to allow the user the edit the transactions while doing this, as long as `shouldAllowUserToEdit` is true.
-6) If the user edits the transaction, and you offer and they accept to save the new mapping, call `saveMapped(description:payee:accountName:)`.
-7) Get `balancesToImport()` and `pricesToImport()` from the importer.
+2) Set your `delegate` on the importer.
+3) Call `load()` on the importer.
+4) Call `nextTransaction()` to retrive transaction after transactions till it returns `nil`. It is recommended to allow the user the edit the transactions while doing this, as long as `shouldAllowUserToEdit` is true.
+5) If the user edits the transaction, and you offer and they accept to save the new mapping, call `saveMapped(description:payee:accountName:)`.
+6) Get `balancesToImport()` and `pricesToImport()` from the importer.
 
 ### Settings
 

--- a/Sources/SwiftBeanCountImporter/Importer.swift
+++ b/Sources/SwiftBeanCountImporter/Importer.swift
@@ -93,6 +93,44 @@ public struct ImportedTransaction {
 
 }
 
+/// Protocol of the delegate of an Importer
+public protocol ImporterDelegate: AnyObject {
+
+    /// Request for a user input, which is required for the importer to operate
+    ///
+    /// - Parameters:
+    ///   - name: name of the input required
+    ///   - suggestions: suggestions for the input - may be empty
+    ///   - allowSaving: if the app is allowed to offer the user to save this input
+    ///                  To save it use the importName together with the name as key.
+    ///   - allowSaved: if the app can just respond with a saved value.
+    ///                   E.g. if asked for a username, which has allowSaving on, the library
+    ///                   would first request the input with allowSaved set to true.
+    ///                   But if the username is incorrect it would request again
+    ///                   with allowSaved false, upon which the app should remove the saved value.
+    ///   - completion: function to pass input to. Returns if the input was accepted.
+    ///                 In case an input was not accepted, please call the function again.
+    func requestInput(name: String, suggestions: [String], allowSaving: Bool, allowSaved: Bool, completion: (String) -> Bool)
+
+    // Request for a secret user input, which is required for the importer to operate
+    ///
+    /// - Parameters:
+    ///   - name: name of the input required
+    ///   - isSecret: if the requested input is considered a secret, e.g. to show a password type input field
+    ///   - allowSaving: if the app is allowed to offer the user to save this input
+    ///                  E.g. this could be true for a password but false for an OTP.
+    ///                  To save it use the importName together with the name as key.
+    ///   - allowSaved: if the app can just respond with a saved value.
+    ///                   E.g. if asked for a password, which has allowSaving on, the library
+    ///                   would first request the input with allowSaved set to true.
+    ///                   But if the password is incorrect it would request again
+    ///                   with allowSaved false, upon which the app should remove the saved value.
+    ///   - completion: function to pass input to. Returns if the input was accepted.
+    ///                 In case an input was not accepted, please call the function again.
+    func requestSecretInput(name: String, allowSaving: Bool, allowSaved: Bool, completion: (String) -> Bool)
+
+}
+
 /// Protocol to represent an Importer, regardless of type
 public protocol Importer {
 
@@ -102,15 +140,8 @@ public protocol Importer {
     /// account selection or credentials
     var importName: String { get }
 
-    /// Get possible account names for this importer
-    func possibleAccountNames() -> [AccountName]
-
-    /// Tells the importer to use the named account for the import.
-    ///
-    /// Must be called before importing if `possibleAccountNames` does not return
-    /// exactly one account
-    /// - Parameter name: name for the accout to use
-    func useAccount(name: AccountName)
+    /// Delegate to request input
+    var delegate: ImporterDelegate? { get set }
 
     /// Loads the data to import
     ///

--- a/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/ManuLifeImporter.swift
@@ -53,7 +53,7 @@ class ManuLifeImporter: BaseImporter, TransactionBalanceTextImporter {
     private let balanceInputString: String
 
     private var accountString: String { configuredAccountName.fullName.split(separator: ":").dropLast(1).joined(separator: ":") }
-    private var account: Account? { ledger?.accounts.first { $0.name == accountName } }
+    private var account: Account? { ledger?.accounts.first { $0.name == configuredAccountName } }
     private var employeeBasicFraction: Double { Double(account?.metaData["employee-basic-fraction"] ?? "") ?? defaultContribution }
     private var employerBasicFraction: Double { Double(account?.metaData["employer-basic-fraction"] ?? "") ?? defaultContribution }
     private var employerMatchFraction: Double { Double(account?.metaData["employer-match-fraction"] ?? "") ?? defaultContribution }

--- a/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/CSVBaseImporterTests.swift
@@ -41,10 +41,11 @@ final class CSVBaseImporterTests: XCTestCase {
 
     func testLoad() {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.basicCSVReader, fileName: "")
+        importer.delegate = TestUtils.cashAccountDelegate
+
         importer.load()
         // Can be called multiple times, still only returns each row once
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
 
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
@@ -55,8 +56,8 @@ final class CSVBaseImporterTests: XCTestCase {
 
     func testLoadSortDate() {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.dateMixedCSVReader, fileName: "")
+        importer.delegate = TestUtils.cashAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
 
         let importedTransaction1 = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction1)
@@ -68,9 +69,8 @@ final class CSVBaseImporterTests: XCTestCase {
 
     func testNextTransaction() {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.basicCSVReader, fileName: "")
-
+        importer.delegate = TestUtils.cashAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
 
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
@@ -140,8 +140,8 @@ final class CSVBaseImporterTests: XCTestCase {
         ledger.add(transaction)
 
         let importer = TestCSVBaseImporter(ledger: ledger, csvReader: TestUtils.csvReader(description: "a", payee: "b", date: transaction.metaData.date), fileName: "")
+        importer.delegate = TestUtils.cashAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertEqual(importedTransaction!.possibleDuplicate, transaction)
@@ -155,8 +155,10 @@ final class CSVBaseImporterTests: XCTestCase {
         ledger.add(transaction)
 
         let importer = TestCSVBaseImporter(ledger: ledger, csvReader: TestUtils.csvReader(description: "a", payee: "b", date: transaction.metaData.date), fileName: "")
+        let delegate = AccountNameProvider(account: TestUtils.chequing)
+        importer.delegate = TestUtils.cashAccountDelegate
+        importer.delegate = delegate
         importer.load()
-        importer.useAccount(name: TestUtils.chequing)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertNil(importedTransaction!.possibleDuplicate)
@@ -186,8 +188,8 @@ final class CSVBaseImporterTests: XCTestCase {
 
     private func transactionHelper(description: String, payee: String = "payee") -> Transaction {
         let importer = TestCSVBaseImporter(ledger: nil, csvReader: TestUtils.csvReader(description: description, payee: payee), fileName: "")
+        importer.delegate = TestUtils.cashAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.cash)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         return importedTransaction!.transaction

--- a/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
+++ b/Tests/SwiftBeanCountImporterTests/Importers/ManuLifeImporterTests.swift
@@ -143,8 +143,8 @@ final class ManuLifeImporterTests: XCTestCase {
 
     func testParseEmpty() {
         let importer = ManuLifeImporter(ledger: nil, transaction: "", balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         XCTAssertNil(importer.nextTransaction())
         XCTAssertEqual(importer.balancesToImport(), [])
         XCTAssertEqual(importer.pricesToImport(), [])
@@ -152,8 +152,8 @@ final class ManuLifeImporterTests: XCTestCase {
 
     func testParseBalance() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: "", balance: balance)
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         XCTAssertNil(importer.nextTransaction())
         let balances = importer.balancesToImport()
         let prices = importer.pricesToImport()
@@ -168,8 +168,8 @@ final class ManuLifeImporterTests: XCTestCase {
 
     func testTransaction() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transaction, balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertEqual(transaction!.originalDescription, "")
@@ -188,8 +188,8 @@ final class ManuLifeImporterTests: XCTestCase {
 
     func testBalanceAndTransaction() {
         let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: transaction, balance: balance)
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         let balances = importer.balancesToImport()
@@ -204,8 +204,8 @@ final class ManuLifeImporterTests: XCTestCase {
 
     func testNoLedger() {
         let importer = ManuLifeImporter(ledger: nil, transaction: transaction, balance: balance)
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         let balances = importer.balancesToImport()
@@ -234,8 +234,8 @@ final class ManuLifeImporterTests: XCTestCase {
         let price2 = try! Price(date: TestUtils.date20200605, commoditySymbol: TestUtils.fundSymbol, amount: priceAmount2)
         try! ledger.add(price2)
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: balance)
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         _ = importer.nextTransaction()
         let balances = importer.balancesToImport()
         let prices = importer.pricesToImport()
@@ -249,8 +249,8 @@ final class ManuLifeImporterTests: XCTestCase {
     func testTransactionSettings() {
         let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "3.25", employerMatch: "2.5", employeeVoluntary: "1.75")
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertTrue(importer.balancesToImport().isEmpty)
@@ -275,8 +275,8 @@ final class ManuLifeImporterTests: XCTestCase {
     func testTransactionSettingsZero1() {
         let ledger = TestUtils.ledgerManuLife(employeeBasic: "2.5", employerBasic: "5", employerMatch: "2.5", employeeVoluntary: "0")
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertTrue(importer.balancesToImport().isEmpty)
@@ -300,8 +300,8 @@ final class ManuLifeImporterTests: XCTestCase {
     func testTransactionSettingsZero2() {
         let ledger = TestUtils.ledgerManuLife(employeeBasic: "0", employerBasic: "0", employerMatch: "0", employeeVoluntary: "1")
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let transaction = importer.nextTransaction()
         XCTAssertNotNil(transaction)
         XCTAssertTrue(importer.balancesToImport().isEmpty)
@@ -321,8 +321,8 @@ final class ManuLifeImporterTests: XCTestCase {
         let strings = ["This is not a valid Transaction", transactionInvalidDate]
         for string in strings {
             let importer = ManuLifeImporter(ledger: TestUtils.ledgerManuLife(), transaction: string, balance: "")
+            importer.delegate = TestUtils.parkingAccountDelegate
             importer.load()
-            importer.useAccount(name: TestUtils.parking)
             XCTAssertNil(importer.nextTransaction())
             XCTAssertEqual(importer.balancesToImport(), [])
             XCTAssertEqual(importer.pricesToImport(), [])
@@ -344,8 +344,8 @@ final class ManuLifeImporterTests: XCTestCase {
         ledger.add(transaction1)
 
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.parking)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertEqual(importedTransaction!.possibleDuplicate, transaction1)
@@ -359,8 +359,8 @@ final class ManuLifeImporterTests: XCTestCase {
         ledger.add(transaction1)
 
         let importer = ManuLifeImporter(ledger: ledger, transaction: transaction, balance: "")
+        importer.delegate = TestUtils.parkingAccountDelegate
         importer.load()
-        importer.useAccount(name: TestUtils.chequing)
         let importedTransaction = importer.nextTransaction()
         XCTAssertNotNil(importedTransaction)
         XCTAssertNil(importedTransaction!.possibleDuplicate)


### PR DESCRIPTION
This method is reusable and for example can be used to get credentials
for the planned downloader importers.