### PR TITLE
EquatePlus Importer: allow 1 day difference

### DIFF
--- a/Sources/SwiftBeanCountImporter/Importers/EquatePlusImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/EquatePlusImporter.swift
@@ -318,7 +318,8 @@ class EquatePlusImporter: BaseImporter, TransactionBalanceTextImporter {
 
         for transaction in transactions {
             if let matchingContribution = contributions.first(where: {
-                $0.purchaseDate == transaction.date && $0.purchasedSharesEmployer == transaction.matchAmount && $0.purchasedSharesYou == transaction.purchaseAmount
+                let range =  Calendar.current.date(byAdding: .day, value: -1, to: $0.purchaseDate)!...Calendar.current.date(byAdding: .day, value: 1, to: $0.purchaseDate)!
+                return range.contains(transaction.date) && $0.purchasedSharesEmployer == transaction.matchAmount && $0.purchasedSharesYou == transaction.purchaseAmount
             }) {
                 result.append(MatchedTransaction(
                     date: transaction.date,

--- a/Sources/SwiftBeanCountImporter/Importers/EquatePlusImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/EquatePlusImporter.swift
@@ -318,7 +318,7 @@ class EquatePlusImporter: BaseImporter, TransactionBalanceTextImporter {
 
         for transaction in transactions {
             if let matchingContribution = contributions.first(where: {
-                let range =  Calendar.current.date(byAdding: .day, value: -1, to: $0.purchaseDate)!...Calendar.current.date(byAdding: .day, value: 1, to: $0.purchaseDate)!
+                let range =  Calendar.current.date(byAdding: .day, value: -1, to: $0.purchaseDate)! ... Calendar.current.date(byAdding: .day, value: 1, to: $0.purchaseDate)!
                 return range.contains(transaction.date) && $0.purchasedSharesEmployer == transaction.matchAmount && $0.purchasedSharesYou == transaction.purchaseAmount
             }) {
                 result.append(MatchedTransaction(

--- a/Sources/SwiftBeanCountImporter/Importers/EquatePlusImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/EquatePlusImporter.swift
@@ -318,7 +318,7 @@ class EquatePlusImporter: BaseImporter, TransactionBalanceTextImporter {
 
         for transaction in transactions {
             if let matchingContribution = contributions.first(where: {
-                let range =  Calendar.current.date(byAdding: .day, value: -1, to: $0.purchaseDate)! ... Calendar.current.date(byAdding: .day, value: 1, to: $0.purchaseDate)!
+                let range = Calendar.current.date(byAdding: .day, value: -1, to: $0.purchaseDate)! ... Calendar.current.date(byAdding: .day, value: 1, to: $0.purchaseDate)!
                 return range.contains(transaction.date) && $0.purchasedSharesEmployer == transaction.matchAmount && $0.purchasedSharesYou == transaction.purchaseAmount
             }) {
                 result.append(MatchedTransaction(


### PR DESCRIPTION
Normally the purchase date listed under contributions is also the one used under transactions. However recently they were 1 day off, so allow for this tolerance