### PR TITLE
Tangerine Download Importer: Do not ask for edit on merge / mapped trans

### DIFF
--- a/Sources/SwiftBeanCountImporter/Importers/TangerineDownloadImporter.swift
+++ b/Sources/SwiftBeanCountImporter/Importers/TangerineDownloadImporter.swift
@@ -158,6 +158,9 @@ class TangerineDownloadImporter: BaseImporter, DownloadImporter {
 
     private func mapTransactions(_ downloadedTransactions: [String: [[String: Any]]]) throws {
         transactions = try mapper.createTransactions(downloadedTransactions).map {
+            if !$0.metaData.payee.isEmpty || $0.metaData.metaData["id"]?.contains(" ") ?? false {
+                return ImportedTransaction($0, shouldAllowUserToEdit: false)
+            }
             var expenseAccounts = [mapper.defaultAccountName]
             let description = sanitize(description: $0.metaData.narration)
             let (savedDescription, savedPayee) = savedDescriptionAndPayeeFor(description: description)


### PR DESCRIPTION
The new Tangerine mapper does support automatically setting payee
for interest and rewards transactions, so these do not need to be
edited anymare
